### PR TITLE
[#145037767] Monitoring of the CDN-Broker

### DIFF
--- a/cmd/cdn-broker/main_test.go
+++ b/cmd/cdn-broker/main_test.go
@@ -16,7 +16,7 @@ func TestBuildHTTPHandler(t *testing.T) {
 		lager.NewLogger("main.test"),
 		brokerapi.BrokerCredentials{},
 	)
-	req, err := http.NewRequest("GET", "http://example.com/healthcheck", nil)
+	req, err := http.NewRequest("GET", "http://example.com/healthcheck/http", nil)
 	if err != nil {
 		t.Error("Building new HTTP request: error should not have occurred")
 	}

--- a/healthchecks/cloudfoundry.go
+++ b/healthchecks/cloudfoundry.go
@@ -1,0 +1,28 @@
+package healthchecks
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/cloudfoundry-community/go-cfclient"
+
+	"github.com/18F/cf-cdn-service-broker/config"
+)
+
+func Cloudfoundry(settings config.Settings) error {
+	// We're only validating that the CF endpoint is contactable here, as
+	// testing the authentication is tricky
+	_, err := cfclient.NewClient(&cfclient.Config{
+		ApiAddress:   settings.APIAddress,
+		ClientID:     settings.ClientID,
+		ClientSecret: settings.ClientSecret,
+		HttpClient: &http.Client{
+			Timeout: time.Second * 10,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/healthchecks/cloudfront.go
+++ b/healthchecks/cloudfront.go
@@ -1,0 +1,22 @@
+package healthchecks
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+
+	"github.com/18F/cf-cdn-service-broker/config"
+)
+
+func Cloudfront(settings config.Settings) error {
+	session := session.New(aws.NewConfig().WithRegion(settings.AwsDefaultRegion))
+	svc := cloudfront.New(session)
+
+	params := &cloudfront.ListDistributionsInput{}
+	_, err := svc.ListDistributions(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/healthchecks/healthchecks.go
+++ b/healthchecks/healthchecks.go
@@ -1,0 +1,49 @@
+package healthchecks
+
+import (
+	"fmt"
+	"github.com/18F/cf-cdn-service-broker/config"
+	"net/http"
+)
+
+var checks = map[string]func(config.Settings) error{
+	"letsencrypt":  LetsEncrypt,
+	"s3":           S3,
+	"cloudfront":   Cloudfront,
+	"cloudfoundry": Cloudfoundry,
+	"postgresql":   Postgresql,
+}
+
+func Bind(mux *http.ServeMux, settings config.Settings) {
+	mux.HandleFunc("/healthcheck", func(w http.ResponseWriter, r *http.Request) {
+		body := ""
+		for name, function := range checks {
+			err := function(settings)
+			if err != nil {
+				body = body + fmt.Sprintf("%s error: %s\n", name, err)
+			}
+		}
+		if body != "" {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, "%s", body)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	mux.HandleFunc("/healthcheck/http", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	for name, function := range checks {
+		mux.HandleFunc("/healthcheck/"+name, func(w http.ResponseWriter, r *http.Request) {
+			err := function(settings)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				fmt.Fprintf(w, "%s error: %s", name, err)
+			} else {
+				w.WriteHeader(http.StatusOK)
+			}
+		})
+	}
+}

--- a/healthchecks/letsencrypt.go
+++ b/healthchecks/letsencrypt.go
@@ -1,0 +1,32 @@
+package healthchecks
+
+import (
+	"crypto"
+	"github.com/xenolf/lego/acme"
+
+	"github.com/18F/cf-cdn-service-broker/config"
+)
+
+type User struct {
+	Email        string
+	Registration *acme.RegistrationResource
+	key          crypto.PrivateKey
+}
+
+func (u *User) GetEmail() string {
+	return u.Email
+}
+
+func (u *User) GetRegistration() *acme.RegistrationResource {
+	return u.Registration
+}
+
+func (u *User) GetPrivateKey() crypto.PrivateKey {
+	return u.key
+}
+
+func LetsEncrypt(settings config.Settings) error {
+	user := &User{key: "cheese"}
+	_, err := acme.NewClient("https://acme-v01.api.letsencrypt.org/directory", user, acme.RSA2048)
+	return err
+}

--- a/healthchecks/postgresql.go
+++ b/healthchecks/postgresql.go
@@ -1,0 +1,19 @@
+package healthchecks
+
+import (
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/postgres"
+
+	"github.com/18F/cf-cdn-service-broker/config"
+)
+
+func Postgresql(settings config.Settings) error {
+	db, err := gorm.Open("postgres", settings.DatabaseUrl)
+	defer db.Close()
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/healthchecks/s3.go
+++ b/healthchecks/s3.go
@@ -1,0 +1,40 @@
+package healthchecks
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+
+	"github.com/18F/cf-cdn-service-broker/config"
+)
+
+func S3(settings config.Settings) error {
+	bucket := settings.Bucket
+	key := "healthcheck-test-key"
+
+	session := session.New(aws.NewConfig().WithRegion(settings.AwsDefaultRegion))
+	svc := s3.New(session)
+
+	input := s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   strings.NewReader("cheese"),
+	}
+
+	_, err := svc.PutObject(&input)
+	if err != nil {
+		return err
+	}
+
+	_, err = svc.DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
# What

This introduces healthcheck endpoints that test communication with all the services that the broker depends on.

* Cloudfoundry (API is contactable)
* Cloudfront (Can authenticate)
* LetsEncrypt (API is contactable)
* Postgresql (Can authenticate)
* S3 (Can authenticate/read/write)

The level of testing varies based on what is feasible in a quick check - for example it's not reasonable to check that Cloudfront can provision a distribution.

The HTTP-only test has moved to /healthchecks/http as /healthchecks now runs all available healthchecks.

# How to test

You don't need to, @LeePorte has already gone through it.

If you DO need to test it, it's easiest to build the binary and overwrite the one on the `cdn_broker` host as this depends on a hell of a lot of environmental services and configuration.

# Who can review

@LeePorte 