### PR TITLE
[#145037767] Fix tests for HTTP handlers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,13 @@ go:
 - "1.7"
 - tip
 
-# Dependencies live in /vendor/
-install: true
+# Only applicable to our fork
+install: |
+  cd ../.. && \
+  mv alphagov 18F && \
+  cd 18F && \
+  mv paas-cdn-broker cf-cdn-service-broker && \
+  cd cf-cdn-service-broker
 
 # Skip vendor tests
 script: go test -v $(go list ./... | grep -v /vendor/)

--- a/cmd/cdn-broker/main_test.go
+++ b/cmd/cdn-broker/main_test.go
@@ -7,15 +7,17 @@ import (
 
 	"code.cloudfoundry.org/lager"
 	"github.com/18F/cf-cdn-service-broker/broker"
+	"github.com/18F/cf-cdn-service-broker/config"
 	"github.com/pivotal-cf/brokerapi"
 )
 
-func TestBuildHTTPHandler(t *testing.T) {
-	handler := buildHTTPHandler(
+func TestHTTPHandler(t *testing.T) {
+	brokerAPI := brokerapi.New(
 		&broker.CdnServiceBroker{},
 		lager.NewLogger("main.test"),
 		brokerapi.BrokerCredentials{},
 	)
+	handler := bindHTTPHandlers(brokerAPI, config.Settings{})
 	req, err := http.NewRequest("GET", "http://example.com/healthcheck/http", nil)
 	if err != nil {
 		t.Error("Building new HTTP request: error should not have occurred")


### PR DESCRIPTION
## What

The refactoring in abcb000 caused the tests to fail with:

    Failed to compile cdn-broker:

    # github.com/18F/cf-cdn-service-broker/cmd/cdn-broker
    cmd/cdn-broker/main_test.go:14: undefined: buildHTTPHandler

Fix them by using the new `func bindHTTPHandlers` instead.

Plus a workaround to run Travis tests on our fork so that we catch these problems in the future.

## How to review

I've enabled Travis on this repo now, so check that the automated tests have passed.

## Who can review

Anyone.