### PR TITLE
Don't log the broker's settings during canary check [#159066591]

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -372,7 +372,6 @@ func (m *RouteManager) stillActive(r *Route) error {
 
 	m.logger.Info("Starting canary check", lager.Data{
 		"route":    r,
-		"settings": m.settings,
 	})
 
 	session := session.New(aws.NewConfig().WithRegion(m.settings.AwsDefaultRegion))


### PR DESCRIPTION
The broker's setting struct contains several secrets we'd prefer not to
log during domain/route liveness checks. We could blacklist or whitelist
specific fields in the logging call, but the additional value of this
information during a canary check is felt to be minimal, given that we have
visibility of the route/domain being requested, as we log it elsewhere if we
encounter a failure.

Instead, we're choosing to remove the settings struct entirely from the log.

[#159066591] CDN broker and CDN broker database credential leakage