### PR TITLE
Clarify that users must set CNAME AND TXT records

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -136,7 +136,7 @@ func (b *CdnServiceBroker) LastOperation(
 			return brokerapi.LastOperation{}, fmt.Errorf("Expected to find %d tokens; found %d", len(route.GetDomains()), len(instructions))
 		}
 		description := fmt.Sprintf(
-			"Provisioning in progress [%s => %s]; CNAME or ALIAS domain %s to %s or create TXT record(s): \n%s",
+			"Provisioning in progress [%s => %s]; CNAME or ALIAS domain %s to %s and create TXT record(s): \n%s",
 			route.DomainExternal, route.Origin, route.DomainExternal, route.DomainInternal,
 			strings.Join(instructions, "\n"),
 		)

--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -28,7 +28,7 @@ cf create-domain "${CF_ORGANIZATION}" "${DOMAIN}"
 opts=$(jq -n --arg domain "${DOMAIN}" '{domain: $domain}')
 cf create-service "${SERVICE_NAME}" "${PLAN_NAME}" "${SERVICE_INSTANCE_NAME}" -c "${opts}"
 
-http_regex="CNAME or ALIAS domain (.*) to (.*) or"
+http_regex="CNAME or ALIAS domain (.*) to (.*) and"
 dns_regex="name: (.*), value: (.*), ttl: (.*)"
 
 elapsed=300


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/3592045

It's confusing to say

>  CNAME or ALIAS domain www.example.com to ...cloudfront.net or create TXT record(s):

When the broker won't work properly unless the user does both the A/CNAME AND the TXT record.