### PR TITLE
[#163524147] Update TLS policy to TLSv1.2_2018

### DIFF
--- a/utils/cloudfront.go
+++ b/utils/cloudfront.go
@@ -136,10 +136,8 @@ func (d *Distribution) fillDistributionConfig(config *cloudfront.DistributionCon
 					HTTPSPort:            aws.Int64(443),
 					OriginProtocolPolicy: getOriginProtocolPolicy(insecureOrigin),
 					OriginSslProtocols: &cloudfront.OriginSslProtocols{
-						Quantity: aws.Int64(3),
+						Quantity: aws.Int64(1),
 						Items: []*string{
-							aws.String("TLSv1"),
-							aws.String("TLSv1.1"),
 							aws.String("TLSv1.2"),
 						},
 					},

--- a/utils/cloudfront.go
+++ b/utils/cloudfront.go
@@ -275,7 +275,7 @@ func (d *Distribution) SetCertificate(distId, certId string) error {
 	DistributionConfig.ViewerCertificate.IAMCertificateId = aws.String(certId)
 	DistributionConfig.ViewerCertificate.CertificateSource = aws.String("iam")
 	DistributionConfig.ViewerCertificate.SSLSupportMethod = aws.String("sni-only")
-	DistributionConfig.ViewerCertificate.MinimumProtocolVersion = aws.String("TLSv1")
+	DistributionConfig.ViewerCertificate.MinimumProtocolVersion = aws.String("TLSv1.2_2018")
 	DistributionConfig.ViewerCertificate.CloudFrontDefaultCertificate = aws.Bool(false)
 
 	_, err = d.Service.UpdateDistribution(&cloudfront.UpdateDistributionInput{


### PR DESCRIPTION
## What

This changes it from the previous one that would allow TLSv1.0 and
TLSv1.1 as well. These protocols are now considered deprecated, so we
should stop using them.

For details on what the TLSv1.2_2018 policy specifies exactly see the
AWS docs - https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html#secure-connections-supported-ciphers

## How to review

Review as part of https://github.com/alphagov/paas-cf/pull/1756

## Who can review

Not me.