### PR TITLE
Update cnames after getting certs

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -260,7 +260,7 @@ func (m *RouteManager) Create(instanceId, domain, origin, path string, insecureO
 		return nil, err
 	}
 
-	dist, err := m.cloudFront.Create(instanceId, route.GetDomains(), origin, path, insecureOrigin, forwardedHeaders, forwardCookies, tags)
+	dist, err := m.cloudFront.Create(instanceId, make([]string, 0), origin, path, insecureOrigin, forwardedHeaders, forwardCookies, tags)
 	if err != nil {
 		return nil, err
 	}
@@ -451,7 +451,7 @@ func (m *RouteManager) Renew(r *Route) error {
 		return err
 	}
 
-	if err := m.deployCertificate(r.InstanceId, r.DistId, certResource); err != nil {
+	if err := m.deployCertificate(*r, certResource); err != nil {
 		return err
 	}
 
@@ -590,7 +590,7 @@ func (m *RouteManager) updateProvisioning(r *Route) error {
 		if err != nil {
 			return err
 		}
-		if err := m.deployCertificate(r.InstanceId, r.DistId, cert); err != nil {
+		if err := m.deployCertificate(*r, cert); err != nil {
 			return err
 		}
 
@@ -660,13 +660,13 @@ func (m *RouteManager) solveChallenges(clients map[acme.Challenge]*acme.Client, 
 	return failures
 }
 
-func (m *RouteManager) deployCertificate(instanceId, distId string, cert acme.CertificateResource) error {
+func (m *RouteManager) deployCertificate(route Route, cert acme.CertificateResource) error {
 	expires, err := acme.GetPEMCertExpiration(cert.Certificate)
 	if err != nil {
 		return err
 	}
 
-	name := fmt.Sprintf("cdn-route-%s-%s", instanceId, expires.Format("2006-01-02_15-04-05"))
+	name := fmt.Sprintf("cdn-route-%s-%s", route.InstanceId, expires.Format("2006-01-02_15-04-05"))
 
 	m.logger.Info("Uploading certificate to IAM", lager.Data{"name": name})
 
@@ -675,7 +675,7 @@ func (m *RouteManager) deployCertificate(instanceId, distId string, cert acme.Ce
 		return err
 	}
 
-	return m.cloudFront.SetCertificate(distId, certId)
+	return m.cloudFront.SetCertificateAndCname(route.DistId, certId, route.GetDomains())
 }
 
 func (m *RouteManager) ensureChallenges(route *Route, client *acme.Client, update bool) error {

--- a/utils/cloudfront.go
+++ b/utils/cloudfront.go
@@ -14,6 +14,7 @@ type DistributionIface interface {
 	Update(distId string, domains []string, origin, path string, insecureOrigin bool, forwardedHeaders Headers, forwardCookies bool) (*cloudfront.Distribution, error)
 	Get(distId string) (*cloudfront.Distribution, error)
 	SetCertificate(distId, certId string) error
+	SetCertificateAndCname(distId, certId string, domains []string) error
 	Disable(distId string) error
 	Delete(distId string) (bool, error)
 	ListDistributions(callback func(cloudfront.DistributionSummary) bool) error
@@ -259,6 +260,33 @@ func (d *Distribution) Get(distId string) (*cloudfront.Distribution, error) {
 	return resp.Distribution, nil
 }
 
+func (d *Distribution) SetCertificateAndCname(distId, certId string, domains []string) error {
+	resp, err := d.Service.GetDistributionConfig(&cloudfront.GetDistributionConfigInput{
+		Id: aws.String(distId),
+	})
+	if err != nil {
+		return err
+	}
+
+	aliases := d.getAliases(domains)
+	DistributionConfig, ETag := resp.DistributionConfig, resp.ETag
+	DistributionConfig.Aliases = aliases
+
+	DistributionConfig.ViewerCertificate.Certificate = aws.String(certId)
+	DistributionConfig.ViewerCertificate.IAMCertificateId = aws.String(certId)
+	DistributionConfig.ViewerCertificate.CertificateSource = aws.String("iam")
+	DistributionConfig.ViewerCertificate.SSLSupportMethod = aws.String("sni-only")
+	DistributionConfig.ViewerCertificate.MinimumProtocolVersion = aws.String("TLSv1.2_2018")
+	DistributionConfig.ViewerCertificate.CloudFrontDefaultCertificate = aws.Bool(false)
+
+	_, err = d.Service.UpdateDistribution(&cloudfront.UpdateDistributionInput{
+		Id:                 aws.String(distId),
+		IfMatch:            ETag,
+		DistributionConfig: DistributionConfig,
+	})
+
+	return err
+}
 func (d *Distribution) SetCertificate(distId, certId string) error {
 	resp, err := d.Service.GetDistributionConfig(&cloudfront.GetDistributionConfigInput{
 		Id: aws.String(distId),

--- a/utils/cloudfront.go
+++ b/utils/cloudfront.go
@@ -13,7 +13,6 @@ type DistributionIface interface {
 	Create(callerReference string, domains []string, origin, path string, insecureOrigin bool, forwardedHeaders Headers, forwardCookies bool, tags map[string]string) (*cloudfront.Distribution, error)
 	Update(distId string, domains []string, origin, path string, insecureOrigin bool, forwardedHeaders Headers, forwardCookies bool) (*cloudfront.Distribution, error)
 	Get(distId string) (*cloudfront.Distribution, error)
-	SetCertificate(distId, certId string) error
 	SetCertificateAndCname(distId, certId string, domains []string) error
 	Disable(distId string) error
 	Delete(distId string) (bool, error)
@@ -271,31 +270,6 @@ func (d *Distribution) SetCertificateAndCname(distId, certId string, domains []s
 	aliases := d.getAliases(domains)
 	DistributionConfig, ETag := resp.DistributionConfig, resp.ETag
 	DistributionConfig.Aliases = aliases
-
-	DistributionConfig.ViewerCertificate.Certificate = aws.String(certId)
-	DistributionConfig.ViewerCertificate.IAMCertificateId = aws.String(certId)
-	DistributionConfig.ViewerCertificate.CertificateSource = aws.String("iam")
-	DistributionConfig.ViewerCertificate.SSLSupportMethod = aws.String("sni-only")
-	DistributionConfig.ViewerCertificate.MinimumProtocolVersion = aws.String("TLSv1.2_2018")
-	DistributionConfig.ViewerCertificate.CloudFrontDefaultCertificate = aws.Bool(false)
-
-	_, err = d.Service.UpdateDistribution(&cloudfront.UpdateDistributionInput{
-		Id:                 aws.String(distId),
-		IfMatch:            ETag,
-		DistributionConfig: DistributionConfig,
-	})
-
-	return err
-}
-func (d *Distribution) SetCertificate(distId, certId string) error {
-	resp, err := d.Service.GetDistributionConfig(&cloudfront.GetDistributionConfigInput{
-		Id: aws.String(distId),
-	})
-	if err != nil {
-		return err
-	}
-
-	DistributionConfig, ETag := resp.DistributionConfig, resp.ETag
 
 	DistributionConfig.ViewerCertificate.Certificate = aws.String(certId)
 	DistributionConfig.ViewerCertificate.IAMCertificateId = aws.String(certId)


### PR DESCRIPTION
What
----

Delay setting CNAMEs until IAM has a valid certificate for the distribution

Why
---

Amazon [have recently changed](https://aws.amazon.com/about-aws/whats-new/2019/04/amazon-cloudfront-enhances-the-security-for-adding-alternate-domain-names-to-a-distribution/) how CloudFront works. Now a valid certificate for any and all alternate names of the distribution are required.

How
---

@bengerman13 has kindly done some of the hard work for us upstream, this PR cherry-picks the commit in. 🙇 👏 

As Miki reports the Update step requires an extra fiddle which is in another commit.

How to review
---

- Code review
- I'm going to run this through my development environment and do some manual testing