### PR TITLE
[#164986888] Log calls to Open Service Broker API endpoints

### DIFF
--- a/broker/broker_bind_test.go
+++ b/broker/broker_bind_test.go
@@ -4,21 +4,38 @@ import (
 	"context"
 	"testing"
 
+	"code.cloudfoundry.org/lager"
+	"github.com/pivotal-cf/brokerapi"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/pivotal-cf/brokerapi"
-
 	"github.com/18F/cf-cdn-service-broker/broker"
+	cfmock "github.com/18F/cf-cdn-service-broker/cf/mocks"
+	"github.com/18F/cf-cdn-service-broker/config"
+	"github.com/18F/cf-cdn-service-broker/models/mocks"
 )
 
 func TestBind(t *testing.T) {
-	b := broker.CdnServiceBroker{}
+	b := broker.New(
+		&mocks.RouteManagerIface{},
+		&cfmock.Client{},
+		config.Settings{
+			DefaultOrigin: "origin.cloud.gov",
+		},
+		lager.NewLogger("test"),
+	)
 	_, err := b.Bind(context.Background(), "", "", brokerapi.BindDetails{})
 	assert.NotNil(t, err)
 }
 
 func TestUnbind(t *testing.T) {
-	b := broker.CdnServiceBroker{}
+	b := broker.New(
+		&mocks.RouteManagerIface{},
+		&cfmock.Client{},
+		config.Settings{
+			DefaultOrigin: "origin.cloud.gov",
+		},
+		lager.NewLogger("test"),
+	)
 	err := b.Unbind(context.Background(), "", "", brokerapi.UnbindDetails{})
 	assert.NotNil(t, err)
 }

--- a/broker/broker_last_operation_test.go
+++ b/broker/broker_last_operation_test.go
@@ -35,6 +35,7 @@ type LastOperationSuite struct {
 func (s *LastOperationSuite) SetupTest() {
 	s.Manager = mocks.RouteManagerIface{}
 	s.cfclient = cfmock.Client{}
+	s.logger = lager.NewLogger("test")
 	s.Broker = broker.New(
 		&s.Manager,
 		&s.cfclient,

--- a/broker/broker_provision_test.go
+++ b/broker/broker_provision_test.go
@@ -36,6 +36,7 @@ type ProvisionSuite struct {
 func (s *ProvisionSuite) SetupTest() {
 	s.Manager = mocks.RouteManagerIface{}
 	s.cfclient = cfmock.Client{}
+	s.logger = lager.NewLogger("test")
 	s.settings = config.Settings{
 		DefaultOrigin: "origin.cloud.gov",
 	}

--- a/broker/broker_update_test.go
+++ b/broker/broker_update_test.go
@@ -36,6 +36,7 @@ type UpdateSuite struct {
 func (s *UpdateSuite) SetupTest() {
 	s.Manager = mocks.RouteManagerIface{}
 	s.cfclient = cfmock.Client{}
+	s.logger = lager.NewLogger("test")
 	s.settings = config.Settings{
 		DefaultOrigin: "origin.cloud.gov",
 	}


### PR DESCRIPTION
## What

Adds info-level logging of calls to the Open Service Broker API endpoints.

## How to review

* See if the tests go green;
* Code review;
* Deploy in a dev env and try provisioning, deprovisioning, updating, etc.

## Who can review

Not @46bit