### PR TITLE
[#167564480] Handle Cloudfront CNAMEAlreadyExists failure

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -155,6 +155,12 @@ func (b *CdnServiceBroker) LastOperation(
 			"domain": route.DomainExternal,
 			"state":  route.State,
 		})
+		if strings.Contains(err.Error(), "CNAMEAlreadyExists") {
+			return brokerapi.LastOperation{
+				State:       brokerapi.Failed,
+				Description: "One or more of the CNAMEs you provided are already associated with a different CDN",
+			}, nil
+		}
 	}
 
 	lsession.Info("provisioning-state", lager.Data{


### PR DESCRIPTION
What 
---------

When the broker currently receives a CNAMEAlreadyExists error from Cloudfront during its last operation, it continues to request certificates from letsencrypt which can result in a rate limitation. This handles the error by returning a broker failure.

How to review
-----------

Code review

Who can review
---------

Not me