### PR TITLE
[#167565279] Change the default cache TTL to 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,15 @@ $ cf create-service cdn-route cdn-route my-cdn-route \
 Create in progress. Use 'cf services' or 'cf service my-cdn-route' to check operation status.
 ```
 
+The default TTL for the CloudFront distribution is `0`. To change this, you can pass it as a parameter:
+
+```bash
+$ cf create-service cdn-route cdn-route my-cdn-route \
+    -c '{"domain": "my.domain.gov", "default_ttl": 12345}'
+
+Create in progress. Use 'cf services' or 'cf service my-cdn-route' to check operation status.
+```
+
 ## Cookie Forwarding
 
 If you do not want cookies forwarded to your origin, you'll need to add another parameter:

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -21,6 +21,7 @@ type Options struct {
 	Domain         string   `json:"domain"`
 	Origin         string   `json:"origin"`
 	Path           string   `json:"path"`
+	DefaultTTL     int64    `json:"default_ttl"`
 	InsecureOrigin bool     `json:"insecure_origin"`
 	Cookies        bool     `json:"cookies"`
 	Headers        []string `json:"headers"`
@@ -116,7 +117,7 @@ func (b *CdnServiceBroker) Provision(
 		"Plan":         details.PlanID,
 	}
 
-	_, err = b.manager.Create(instanceID, options.Domain, options.Origin, options.Path, options.InsecureOrigin, headers, options.Cookies, tags)
+	_, err = b.manager.Create(instanceID, options.Domain, options.Origin, options.Path, options.DefaultTTL, options.InsecureOrigin, headers, options.Cookies, tags)
 	if err != nil {
 		lsession.Info("manager-create-err", lager.Data{
 			"options": options,
@@ -322,7 +323,9 @@ func (b *CdnServiceBroker) Update(
 
 	provisioningAsync, err := b.manager.Update(
 		instanceID,
-		options.Domain, options.Origin, options.Path, options.InsecureOrigin,
+		options.Domain, options.Origin, options.Path,
+		options.DefaultTTL,
+		options.InsecureOrigin,
 		headers, options.Cookies,
 	)
 	if err != nil {
@@ -342,6 +345,7 @@ func (b *CdnServiceBroker) createBrokerOptions(details []byte) (options Options,
 		Origin:  b.settings.DefaultOrigin,
 		Cookies: true,
 		Headers: []string{},
+		DefaultTTL: b.settings.DefaultDefaultTTL,
 	}
 	err = json.Unmarshal(details, &options)
 	if err != nil {

--- a/broker/broker_update_test.go
+++ b/broker/broker_update_test.go
@@ -32,11 +32,11 @@ type UpdateSuite struct {
 }
 
 func (s *UpdateSuite) allowUpdateWithExpectedHeaders(expectedHeaders utils.Headers) {
-	s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", ".", true, expectedHeaders, true).Return(nil)
+	s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", ".", s.settings.DefaultDefaultTTL, true, expectedHeaders, true).Return(nil)
 }
 
 func (s *UpdateSuite) failOnUpdateWithExpectedHeaders(expectedHeaders utils.Headers) {
-	s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", ".", true, expectedHeaders, true).Return(errors.New("fail"))
+	s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", ".", s.settings.DefaultDefaultTTL, true, expectedHeaders, true).Return(errors.New("fail"))
 }
 
 var _ = Describe("Update", func() {
@@ -48,6 +48,7 @@ var _ = Describe("Update", func() {
 		s.logger = lager.NewLogger("test")
 		s.settings = config.Settings{
 			DefaultOrigin: "origin.cloud.gov",
+			DefaultDefaultTTL: int64(0),
 		}
 		s.Broker = broker.New(
 			&s.Manager,
@@ -72,7 +73,7 @@ var _ = Describe("Update", func() {
 		details := brokerapi.UpdateDetails{
 			RawParameters: json.RawMessage(`{"domain": "domain.gov"}`),
 		}
-		s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", "", false, utils.Headers{"Host": true}, true).Return(nil)
+		s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", "", s.settings.DefaultDefaultTTL, false, utils.Headers{"Host": true}, true).Return(nil)
 		s.cfclient.On("GetDomainByName", "domain.gov").Return(cfclient.Domain{}, nil)
 		_, err := s.Broker.Update(s.ctx, "", details, true)
 
@@ -83,7 +84,7 @@ var _ = Describe("Update", func() {
 		details := brokerapi.UpdateDetails{
 			RawParameters: json.RawMessage(`{"origin": "origin.gov"}`),
 		}
-		s.Manager.On("Update", "", "", "origin.gov", "", false, utils.Headers{}, true).Return(nil)
+		s.Manager.On("Update", "", "", "origin.gov", "", s.settings.DefaultDefaultTTL, false, utils.Headers{}, true).Return(nil)
 		s.cfclient.On("GetDomainByName", "domain.gov").Return(cfclient.Domain{}, nil)
 		_, err := s.Broker.Update(s.ctx, "", details, true)
 
@@ -98,7 +99,7 @@ var _ = Describe("Update", func() {
 				"path": "."
 			}`),
 		}
-		s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", ".", true, utils.Headers{"Host": true}, true).Return(nil)
+		s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", ".", s.settings.DefaultDefaultTTL, true, utils.Headers{"Host": true}, true).Return(nil)
 		s.cfclient.On("GetDomainByName", "domain.gov").Return(cfclient.Domain{}, nil)
 		_, err := s.Broker.Update(s.ctx, "", details, true)
 

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,7 @@ type Settings struct {
 	ClientID             string `envconfig:"client_id" required:"true"`
 	ClientSecret         string `envconfig:"client_secret" required:"true"`
 	DefaultOrigin        string `envconfig:"default_origin" required:"true"`
+	DefaultDefaultTTL    int64  `envconfig:"default_default_ttl" default:"0"`
 	Schedule             string `envconfig:"schedule" default:"0 0 * * * *"`
 }
 

--- a/models/mocks/RouteManagerIface.go
+++ b/models/mocks/RouteManagerIface.go
@@ -11,13 +11,13 @@ type RouteManagerIface struct {
 	mock.Mock
 }
 
-// Create provides a mock function with given fields: instanceId, domain, origin, path, insecureOrigin, forwardedHeaders, forwardCookies, tags
-func (_m *RouteManagerIface) Create(instanceId string, domain string, origin string, path string, insecureOrigin bool, forwardedHeaders utils.Headers, forwardCookies bool, tags map[string]string) (*models.Route, error) {
-	ret := _m.Called(instanceId, domain, origin, path, insecureOrigin, forwardedHeaders, forwardCookies, tags)
+// Create provides a mock function with given fields: instanceId, domain, origin, path, defaultTTL,  insecureOrigin, forwardedHeaders, forwardCookies, tags
+func (_m *RouteManagerIface) Create(instanceId string, domain string, origin string, path string, defaultTTL int64, insecureOrigin bool, forwardedHeaders utils.Headers, forwardCookies bool, tags map[string]string) (*models.Route, error) {
+	ret := _m.Called(instanceId, domain, origin, path,  defaultTTL,  insecureOrigin, forwardedHeaders, forwardCookies, tags)
 
 	var r0 *models.Route
-	if rf, ok := ret.Get(0).(func(string, string, string, string, bool, utils.Headers, bool, map[string]string) *models.Route); ok {
-		r0 = rf(instanceId, domain, origin, path, insecureOrigin, forwardedHeaders, forwardCookies, tags)
+	if rf, ok := ret.Get(0).(func(string, string, string, string, int64, bool, utils.Headers, bool, map[string]string) *models.Route); ok {
+		r0 = rf(instanceId, domain, origin, path, defaultTTL,  insecureOrigin, forwardedHeaders, forwardCookies, tags)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.Route)
@@ -25,8 +25,8 @@ func (_m *RouteManagerIface) Create(instanceId string, domain string, origin str
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string, string, string, bool, utils.Headers, bool, map[string]string) error); ok {
-		r1 = rf(instanceId, domain, origin, path, insecureOrigin, forwardedHeaders, forwardCookies, tags)
+	if rf, ok := ret.Get(1).(func(string, string, string, string, int64, bool, utils.Headers, bool, map[string]string) error); ok {
+		r1 = rf(instanceId, domain, origin, path, defaultTTL,  insecureOrigin, forwardedHeaders, forwardCookies, tags)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -133,12 +133,12 @@ func (_m *RouteManagerIface) RenewAll() {
 }
 
 // Update provides a mock function with given fields: instanceId, domain, origin, path, insecureOrigin, forwardedHeaders, forwardCookies
-func (_m *RouteManagerIface) Update(instanceId string, domain string, origin string, path string, insecureOrigin bool, forwardedHeaders utils.Headers, forwardCookies bool) (bool, error) {
-	ret := _m.Called(instanceId, domain, origin, path, insecureOrigin, forwardedHeaders, forwardCookies)
+func (_m *RouteManagerIface) Update(instanceId string, domain string, origin string, path string, defaultTTL int64, insecureOrigin bool, forwardedHeaders utils.Headers, forwardCookies bool) (bool, error) {
+	ret := _m.Called(instanceId, domain, origin, path, defaultTTL,  insecureOrigin, forwardedHeaders, forwardCookies)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string, string, bool, utils.Headers, bool) error); ok {
-		r0 = rf(instanceId, domain, origin, path, insecureOrigin, forwardedHeaders, forwardCookies)
+	if rf, ok := ret.Get(0).(func(string, string, string, string, int64, bool, utils.Headers, bool) error); ok {
+		r0 = rf(instanceId, domain, origin, path, defaultTTL,  insecureOrigin, forwardedHeaders, forwardCookies)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/models/models.go
+++ b/models/models.go
@@ -187,6 +187,7 @@ type Route struct {
 	Certificate    Certificate
 	UserData       UserData
 	UserDataID     int
+	DefaultTTL     int64
 }
 
 func (r *Route) GetDomains() []string {
@@ -218,6 +219,7 @@ type RouteManagerIface interface {
 		domain,
 		origin,
 		path string,
+		defaultTTL int64,
 		insecureOrigin bool,
 		forwardedHeaders utils.Headers,
 		forwardCookies bool,
@@ -229,6 +231,7 @@ type RouteManagerIface interface {
 		domain,
 		origin string,
 		path string,
+		defaultTTL int64,
 		insecureOrigin bool,
 		forwardedHeaders utils.Headers,
 		forwardCookies bool,
@@ -281,6 +284,7 @@ func (m *RouteManager) Create(
 	domain,
 	origin,
 	path string,
+	defaultTTL int64,
 	insecureOrigin bool,
 	forwardedHeaders utils.Headers,
 	forwardCookies bool,
@@ -293,6 +297,7 @@ func (m *RouteManager) Create(
 		DomainExternal: domain,
 		Origin:         origin,
 		Path:           path,
+		DefaultTTL:     defaultTTL,
 		InsecureOrigin: insecureOrigin,
 	}
 
@@ -335,6 +340,7 @@ func (m *RouteManager) Create(
 		make([]string, 0),
 		origin,
 		path,
+		defaultTTL,
 		insecureOrigin,
 		forwardedHeaders,
 		forwardCookies,
@@ -385,6 +391,7 @@ func (m *RouteManager) Update(
 	domain,
 	origin string,
 	path string,
+	defaultTTL int64,
 	insecureOrigin bool,
 	forwardedHeaders utils.Headers,
 	forwardCookies bool,
@@ -421,6 +428,10 @@ func (m *RouteManager) Update(
 		lsession.Info("param-update-path")
 		route.Path = path
 	}
+	if defaultTTL != route.DefaultTTL {
+		lsession.Info("param-update-default-ttl")
+		route.DefaultTTL = defaultTTL
+	}
 	if insecureOrigin != route.InsecureOrigin {
 		lsession.Info("param-update-insecure-origin")
 		route.InsecureOrigin = insecureOrigin
@@ -431,7 +442,9 @@ func (m *RouteManager) Update(
 	dist, err := m.cloudFront.Update(
 		route.DistId,
 		oldDomainsForCloudFront,
-		route.Origin, route.Path, route.InsecureOrigin,
+		route.Origin, route.Path,
+		route.DefaultTTL,
+		route.InsecureOrigin,
 		forwardedHeaders, forwardCookies,
 	)
 	if err != nil {

--- a/models/models.go
+++ b/models/models.go
@@ -187,7 +187,7 @@ type Route struct {
 	Certificate    Certificate
 	UserData       UserData
 	UserDataID     int
-	DefaultTTL     int64
+	DefaultTTL     int64 `gorm:"default:86400"`
 }
 
 func (r *Route) GetDomains() []string {

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -437,6 +437,7 @@ var _ = Describe("Models", func() {
 			domain := "foo.paas.gov.uk"
 			origin := "foo.cloudapps.digital"
 			path := "/"
+			defaultTTL := int64(0)
 			insecureOrigin := false
 			forwardedHeaders := utils.Headers{}
 			forwardCookies := false
@@ -485,7 +486,7 @@ var _ = Describe("Models", func() {
 			)
 
 			_, err := manager.Create(
-				instanceID, domain, origin, path,
+				instanceID, domain, origin, path, defaultTTL,
 				insecureOrigin, forwardedHeaders, forwardCookies, tags,
 			)
 			Expect(acmeProviderMock.GetHTTP01ClientCallCount()).To(
@@ -508,6 +509,7 @@ var _ = Describe("Models", func() {
 			domain := "foo.paas.gov.uk"
 			origin := "foo.cloudapps.digital"
 			path := "/"
+			defaultTTL := int64(0)
 			insecureOrigin := false
 
 			settings, _ := config.NewSettings()
@@ -575,6 +577,7 @@ var _ = Describe("Models", func() {
 				DomainExternal: domain,
 				Origin:         origin,
 				Path:           path,
+				DefaultTTL:defaultTTL,
 				InsecureOrigin: insecureOrigin,
 			}
 
@@ -669,6 +672,7 @@ var _ = Describe("Models", func() {
 			domain := "foo.paas.gov.uk"
 			origin := "foo.cloudapps.digital"
 			path := "/"
+			defaultTTL := int64(0)
 			insecureOrigin := false
 
 			settings, _ := config.NewSettings()
@@ -697,6 +701,7 @@ var _ = Describe("Models", func() {
 				DomainExternal: domain,
 				Origin:         origin,
 				Path:           path,
+				DefaultTTL:		defaultTTL,
 				InsecureOrigin: insecureOrigin,
 			}
 		})
@@ -741,6 +746,7 @@ var _ = Describe("Models", func() {
 			domain           = "foo.paas.gov.uk"
 			origin           = "foo.cloudapps.digital"
 			path             = "/"
+			defaultTTL       = int64(0)
 			insecureOrigin   = false
 			forwardedHeaders = utils.Headers{"X-Forwarded-Five": true}
 			forwardCookies   = false
@@ -846,7 +852,7 @@ var _ = Describe("Models", func() {
 						"created_at", "updated_at", "deleted_at",
 						"id", "challenge_json",
 						"domain_external", "domain_internal",
-						"dist_id", "origin", "path",
+						"dist_id", "origin", "path", "default_ttl",
 						"insecure_origin", "certificate_id", "user_data_id",
 						"state",
 					},
@@ -855,8 +861,8 @@ var _ = Describe("Models", func() {
 					routeID, "[]",
 					domain, "foo.cloudfront.net",
 					cloudfrontDistID, origin, path,
-					false, certificateID, userDataID,
-					"Provisioned",
+					defaultTTL, false, certificateID,
+					userDataID,	"Provisioned",
 				),
 			)
 
@@ -867,7 +873,7 @@ var _ = Describe("Models", func() {
 				"provisioned", // Expect new state to be Provisioned
 				sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
 				sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
-				sqlmock.AnyArg(),
+				sqlmock.AnyArg(), sqlmock.AnyArg(),
 			).WillReturnResult(sqlmock.NewResult(1, 1))
 
 			mockDB.ExpectQuery(
@@ -898,6 +904,7 @@ var _ = Describe("Models", func() {
 				brokerAPICallDomainArgument,
 				origin,
 				path,
+				defaultTTL,
 				insecureOrigin,
 				forwardedHeaders,
 				forwardCookies,
@@ -949,16 +956,16 @@ var _ = Describe("Models", func() {
 						"id", "challenge_json",
 						"domain_external", "domain_internal",
 						"dist_id", "origin", "path",
-						"insecure_origin", "certificate_id", "user_data_id",
-						"state",
+						"default_ttl", "insecure_origin", "certificate_id",
+						"user_data_id", "state",
 					},
 				).AddRow(
 					time.Now(), time.Now(), nil,
 					routeID, "[]",
 					domain, "foo.cloudfront.net",
 					cloudfrontDistID, origin, path,
-					false, certificateID, userDataID,
-					"Provisioned",
+					defaultTTL, false, certificateID,
+					userDataID, "Provisioned",
 				),
 			)
 
@@ -988,7 +995,7 @@ var _ = Describe("Models", func() {
 				"provisioning", // Expect new state to be Provisioning
 				sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
 				sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
-				sqlmock.AnyArg(),
+				sqlmock.AnyArg(), sqlmock.AnyArg(),
 			).WillReturnResult(sqlmock.NewResult(1, 1))
 
 			// we are simulating that someone is updating the distribution, and DOES
@@ -1000,6 +1007,7 @@ var _ = Describe("Models", func() {
 				brokerAPICallDomainArgument,
 				origin,
 				path,
+				defaultTTL,
 				insecureOrigin,
 				forwardedHeaders,
 				forwardCookies,


### PR DESCRIPTION
## What

Change the default caching TTL in new CloudFront distributions from 86400 (1 day) to 0 (0 days).

Allow a custom default TTL to be set via the `default_ttl` config value

## Why

We advertise the CDN broker as being the way to use a custom domain with the PaaS. It comes with caching enabled with a 1 day TTL by default, which is a bit daft as people would not expect this.

## How to review

* Deploy to a dev env and test that a CloudFront distribution is created with a 0 TTL
* Maybe do some updates to see if it changes properly?

## Who can review
Not me - I don't want to see this again.