### PR TITLE
[#167668232] Fix documentation url

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -5,7 +5,7 @@
   "bindable": true,
   "metadata": {
     "displayName": "CDN Route",
-    "documentationUrl": "https://cloud.gov/docs/services/cdn-route/"
+    "documentationUrl": "https://docs.cloud.service.gov.uk/deploying_services/use_a_custom_domain/#managing-custom-domains-using-the-cdn-route-service"
   },
   "plan_updateable": true,
   "plans": [


### PR DESCRIPTION
## What

The documentation URL was still set to 18F (cloud.gov)'s documentation URL, even though we run a fork and have our own documentation.

## How to review

Code review.

## Who can review

Not @46bit