### PR TITLE
[#171132351] Drop unnecessary log line in DNS & HTTP providers

### DIFF
--- a/models/dns_provider.go
+++ b/models/dns_provider.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"code.cloudfoundry.org/lager"
 	"context"
 	"crypto/rsa"
 	"fmt"
@@ -61,9 +60,7 @@ func (acp *AcmeClientProvider) GetDNS01Client(user *utils.User, settings config.
 			TosURL:      "",
 		}
 	}
-
-	logSess.Info("user-registration-resource", lager.Data{"registration": user.Registration})
-
+	
 	logSess.Info("create-legoacme-client")
 	legoClient, err := legoacme.NewClient(settings.AcmeUrl, user, legoacme.RSA2048)
 	if err != nil {

--- a/models/http_provider.go
+++ b/models/http_provider.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"code.cloudfoundry.org/lager"
 	"context"
 	"crypto/rsa"
 	"crypto/tls"
@@ -13,8 +12,8 @@ import (
 	"strings"
 	"time"
 
-	goacme "golang.org/x/crypto/acme"
 	legoacme "github.com/18F/cf-cdn-service-broker/lego/acme"
+	goacme "golang.org/x/crypto/acme"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -70,8 +69,6 @@ func (acp *AcmeClientProvider) GetHTTP01Client(user *utils.User, settings config
 			TosURL:      "",
 		}
 	}
-
-	logSess.Info("user-registration-resource", lager.Data{"registration": user.Registration})
 
 	logSess.Info("create-legoacme-client")
 	legoclient, err := legoacme.NewClient(settings.AcmeUrl, user, legoacme.RSA2048)


### PR DESCRIPTION
What
---
The DNS & HTTP ACME client providers were emitting a log line that contained
some data we wouldn't want logged. This commit drops that line entirely, since
the line doesn't help in debugging anything anyway.

How to review
---
1. Code review. It doesn't change any behaviour

Who can review
---
Anyone