### PR TITLE
Expire provisioning after 24h

### DIFF
--- a/broker/broker_last_operation_test.go
+++ b/broker/broker_last_operation_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Last operation", func() {
 		operation, err := b.LastOperation(s.ctx, "123", brokerapi.PollDetails{OperationData: ""})
 		Expect(operation.State).To(Equal(brokerapi.InProgress))
 		Expect(operation.Description).To(ContainSubstring(operation.Description))
-		Expect(operation.Description).To(ContainSubstring("Couldn't verify in 24h time slot. Deprovisioning in progress [cdn.cloud.gov => cdn.apps.cloud.gov]"))
+		Expect(operation.Description).To(ContainSubstring("Couldn't verify in 24h time slot. Expiring instance initialisation."))
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -169,7 +169,7 @@ var _ = Describe("Last operation", func() {
 		operation, err := b.LastOperation(s.ctx, "123", brokerapi.PollDetails{OperationData: ""})
 		Expect(operation.State).To(Equal(brokerapi.Failed))
 		Expect(operation.Description).To(ContainSubstring(operation.Description))
-		Expect(operation.Description).To(ContainSubstring("Couldn't verify in 24h time slot. Automatic deprovisioning has failed. Please contact support."))
+		Expect(operation.Description).To(ContainSubstring("Couldn't verify in 24h time slot. Self-healing has failed. Please contact support."))
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/broker/broker_last_operation_test.go
+++ b/broker/broker_last_operation_test.go
@@ -3,7 +3,10 @@ package broker_test
 import (
 	"context"
 	"errors"
+	"fmt"
+	"time"
 
+	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/suite"
 
 	"code.cloudfoundry.org/lager"
@@ -91,6 +94,9 @@ var _ = Describe("Last operation", func() {
 			DomainExternal: "cdn.cloud.gov",
 			Origin:         "cdn.apps.cloud.gov",
 			ChallengeJSON:  []byte("[]"),
+			Model: gorm.Model{
+				CreatedAt: time.Now().Add(-5 * time.Minute),
+			},
 		}
 		manager.On("Get", "123").Return(route, nil)
 		manager.On("GetDNSInstructions", route).Return([]string{"token"}, nil)
@@ -106,6 +112,64 @@ var _ = Describe("Last operation", func() {
 		Expect(operation.State).To(Equal(brokerapi.InProgress))
 		Expect(operation.Description).To(ContainSubstring(operation.Description))
 		Expect(operation.Description).To(ContainSubstring("Provisioning in progress [cdn.cloud.gov => cdn.apps.cloud.gov]"))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Should resolve in deprovisioning if takes more than 24h", func() {
+		manager := mocks.RouteManagerIface{}
+		route := &models.Route{
+			State:          models.Provisioning,
+			DomainExternal: "cdn.cloud.gov",
+			Origin:         "cdn.apps.cloud.gov",
+			ChallengeJSON:  []byte("[]"),
+			Model: gorm.Model{
+				CreatedAt: time.Now().Add(-48 * time.Hour),
+			},
+		}
+		manager.On("Get", "123").Return(route, nil)
+		manager.On("GetDNSInstructions", route).Return([]string{"token"}, nil)
+		manager.On("Poll", route).Return(nil)
+		manager.On("Disable", route).Return(nil)
+		b := broker.New(
+			&manager,
+			&s.cfclient,
+			s.settings,
+			s.logger,
+		)
+
+		operation, err := b.LastOperation(s.ctx, "123", brokerapi.PollDetails{OperationData: ""})
+		Expect(operation.State).To(Equal(brokerapi.InProgress))
+		Expect(operation.Description).To(ContainSubstring(operation.Description))
+		Expect(operation.Description).To(ContainSubstring("Couldn't verify in 24h time slot. Deprovisioning in progress [cdn.cloud.gov => cdn.apps.cloud.gov]"))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Should fail if takes more than 24h and is unable to Disable the instance", func() {
+		manager := mocks.RouteManagerIface{}
+		route := &models.Route{
+			State:          models.Provisioning,
+			DomainExternal: "cdn.cloud.gov",
+			Origin:         "cdn.apps.cloud.gov",
+			ChallengeJSON:  []byte("[]"),
+			Model: gorm.Model{
+				CreatedAt: time.Now().Add(-48 * time.Hour),
+			},
+		}
+		manager.On("Get", "123").Return(route, nil)
+		manager.On("GetDNSInstructions", route).Return([]string{"token"}, nil)
+		manager.On("Poll", route).Return(nil)
+		manager.On("Disable", route).Return(fmt.Errorf("TEST_SUITE"))
+		b := broker.New(
+			&manager,
+			&s.cfclient,
+			s.settings,
+			s.logger,
+		)
+
+		operation, err := b.LastOperation(s.ctx, "123", brokerapi.PollDetails{OperationData: ""})
+		Expect(operation.State).To(Equal(brokerapi.Failed))
+		Expect(operation.Description).To(ContainSubstring(operation.Description))
+		Expect(operation.Description).To(ContainSubstring("Couldn't verify in 24h time slot. Automatic deprovisioning has failed. Please contact support."))
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
## What

We're currently having a situation, where users can provision CDN Route
and then have 24h to setup their DNS' CNAME and TXT pointing to the
instance we provision. If this takes more than 24h, the broker deletes
the certificates and stops attempts of checking for the correct
configuration. This leaves the instance in stuck state, where users are
not able to delete the instance themselves, as the API claims it's still
being provisioned, and leaves us with the support burden of the operator
having to need to change database entry and delete the instance with
their super powers.

This change, will check if the instance has been created more than 24h
than the current action, and will attempt to delete the instance or set
its state to failed.

The assumption is that the platform will self heal from the broken
instance or expose user with an error and failed state, that will allow
them to manually delete the entry.

## How to review

- Deploy to your environment
- Create CDN route service with random domain you cannot possibly modify
- Wait 24h
- Check up and either, see no service or see it failing
- If it's failing, manually remove it and see if it's possible
