### PR TITLE
[#171896697] Fix the missing origin keepalive timeout

### DIFF
--- a/utils/cloudfront.go
+++ b/utils/cloudfront.go
@@ -133,10 +133,11 @@ func (d *Distribution) fillDistributionConfig(config *cloudfront.DistributionCon
 					Quantity: aws.Int64(0),
 				},
 				CustomOriginConfig: &cloudfront.CustomOriginConfig{
-					HTTPPort:             aws.Int64(80),
-					HTTPSPort:            aws.Int64(443),
-					OriginReadTimeout:    aws.Int64(60),
-					OriginProtocolPolicy: getOriginProtocolPolicy(insecureOrigin),
+					HTTPPort:               aws.Int64(80),
+					HTTPSPort:              aws.Int64(443),
+					OriginReadTimeout:      aws.Int64(60),
+					OriginKeepaliveTimeout: aws.Int64(5),
+					OriginProtocolPolicy:   getOriginProtocolPolicy(insecureOrigin),
 					OriginSslProtocols: &cloudfront.OriginSslProtocols{
 						Quantity: aws.Int64(1),
 						Items: []*string{


### PR DESCRIPTION
## What

In #29 we started setting the Origin Read Timeout to 60 seconds. Now a bug has appeared when trying to update an existing CDN route:

```
$ cf update-service my-cdn-route -c '{"headers": ["Accept", "Authorization", "Host"]}'
Server error, status code: 502, error code: 10001, message: Service broker error: IllegalUpdate: OriginKeepaliveTimeout is required for updates.
    status code: 400, request id: 5a76887e-1e3d-4d8b-af86-9eece2291d06
```
    
Amazon's documentation explicitly says that `OriginKeepaliveTimeout` is not required, but it seems like it is for updates that specify the read timeout.

This commit starts specifying `OriginKeepaliveTimeout` and sets it to the default which is 5 seconds.

See Amazon's docs: https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CustomOriginConfig.html#cloudfront-Type-CustomOriginConfig-OriginKeepaliveTimeout.

## How to review

Deploy it and see.

## Who can review

Not me.