### PR TITLE
Disallow service updates

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -322,33 +322,7 @@ func (b *CdnServiceBroker) Update(
 		"details":     details,
 	})
 
-	if !asyncAllowed {
-		return brokerapi.UpdateServiceSpec{}, brokerapi.ErrAsyncRequired
-	}
-
-	options, err := b.parseUpdateDetails(details)
-	if err != nil {
-		return brokerapi.UpdateServiceSpec{}, err
-	}
-	b.logger.Info("update-options", lager.Data{"instance_id": instanceID, "options": options})
-
-	headers, err := b.getHeaders(options)
-	if err != nil {
-		return brokerapi.UpdateServiceSpec{}, err
-	}
-
-	provisioningAsync, err := b.manager.Update(
-		instanceID,
-		options.Domain, options.Origin, options.Path,
-		options.DefaultTTL,
-		options.InsecureOrigin,
-		headers, options.Cookies,
-	)
-	if err != nil {
-		return brokerapi.UpdateServiceSpec{}, err
-	}
-
-	return brokerapi.UpdateServiceSpec{IsAsync: provisioningAsync}, nil
+	return brokerapi.UpdateServiceSpec{}, errors.New("service no longer supports updates. please contact support with your query")
 }
 
 // createBrokerOptions will attempt to take raw json and convert it into the "Options" struct.

--- a/broker/broker_update_test.go
+++ b/broker/broker_update_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"code.cloudfoundry.org/lager"
-	"github.com/cloudfoundry-community/go-cfclient"
 	"github.com/pivotal-cf/brokerapi"
 
 	"github.com/18F/cf-cdn-service-broker/broker"
@@ -47,7 +46,7 @@ var _ = Describe("Update", func() {
 		s.cfclient = cfmock.Client{}
 		s.logger = lager.NewLogger("test")
 		s.settings = config.Settings{
-			DefaultOrigin: "origin.cloud.gov",
+			DefaultOrigin:     "origin.cloud.gov",
 			DefaultDefaultTTL: int64(0),
 		}
 		s.Broker = broker.New(
@@ -59,170 +58,13 @@ var _ = Describe("Update", func() {
 		s.ctx = context.Background()
 	})
 
-	It("Should error when not given options", func() {
+	It("should error due to lack of update support", func() {
 		details := brokerapi.UpdateDetails{
 			RawParameters: json.RawMessage(`{"origin": ""}`),
 		}
 		_, err := s.Broker.Update(s.ctx, "", details, true)
 
 		Expect(err).To(HaveOccurred())
-		Expect(err).To(MatchError(ContainSubstring("must pass non-empty `domain` or `origin`")))
-	})
-
-	It("Should succeed when given only a domain", func() {
-		details := brokerapi.UpdateDetails{
-			RawParameters: json.RawMessage(`{"domain": "domain.gov"}`),
-		}
-		s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", "", s.settings.DefaultDefaultTTL, false, utils.Headers{"Host": true}, true).Return(nil)
-		s.cfclient.On("GetDomainByName", "domain.gov").Return(cfclient.Domain{}, nil)
-		_, err := s.Broker.Update(s.ctx, "", details, true)
-
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("Should succeed when given only an origin", func() {
-		details := brokerapi.UpdateDetails{
-			RawParameters: json.RawMessage(`{"origin": "origin.gov"}`),
-		}
-		s.Manager.On("Update", "", "", "origin.gov", "", s.settings.DefaultDefaultTTL, false, utils.Headers{}, true).Return(nil)
-		s.cfclient.On("GetDomainByName", "domain.gov").Return(cfclient.Domain{}, nil)
-		_, err := s.Broker.Update(s.ctx, "", details, true)
-
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("Should succeed when given origin and path and insecure_origin", func() {
-		details := brokerapi.UpdateDetails{
-			RawParameters: json.RawMessage(`{
-				"insecure_origin": true,
-				"domain": "domain.gov",
-				"path": "."
-			}`),
-		}
-		s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", ".", s.settings.DefaultDefaultTTL, true, utils.Headers{"Host": true}, true).Return(nil)
-		s.cfclient.On("GetDomainByName", "domain.gov").Return(cfclient.Domain{}, nil)
-		_, err := s.Broker.Update(s.ctx, "", details, true)
-
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("Should error when Cloud Foundry domain does not exist", func() {
-		details := brokerapi.UpdateDetails{
-			PreviousValues: brokerapi.PreviousValues{
-				OrgID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
-			},
-			RawParameters: json.RawMessage(`{"domain": "domain.gov"}`),
-		}
-		s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", ".", true, utils.Headers{"Host": true}, true).Return(nil)
-		s.cfclient.On("GetOrgByGuid", "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5").Return(cfclient.Org{Name: "my-org"}, nil)
-		s.cfclient.On("GetDomainByName", "domain.gov").Return(cfclient.Domain{}, errors.New("bad"))
-		_, err := s.Broker.Update(s.ctx, "", details, true)
-
-		Expect(err).To(HaveOccurred())
-		Expect(err).To(MatchError(ContainSubstring("cf create-domain")))
-	})
-
-	Context("Headers", func() {
-		BeforeEach(func() {
-			s.cfclient.On("GetDomainByName", "domain.gov").Return(cfclient.Domain{}, nil)
-		})
-
-		It("Should succeed when forwarding duplicated host headers", func() {
-			s.allowUpdateWithExpectedHeaders(utils.Headers{"Host": true})
-
-			details := brokerapi.UpdateDetails{
-				RawParameters: json.RawMessage(`{
-			"insecure_origin": true,
-			"domain": "domain.gov",
-			"path": ".",
-			"headers": ["Host"]
-		}`),
-			}
-			_, err := s.Broker.Update(s.ctx, "", details, true)
-
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("Should succeed when forwarding a single header", func() {
-			s.allowUpdateWithExpectedHeaders(utils.Headers{"User-Agent": true, "Host": true})
-
-			details := brokerapi.UpdateDetails{
-				RawParameters: json.RawMessage(`{
-"insecure_origin": true,
-			"domain": "domain.gov",
-			"path": ".",
-			"headers": ["User-Agent"]
-		}`),
-			}
-			_, err := s.Broker.Update(s.ctx, "", details, true)
-
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("Should succeed when forwarding wildcard headers", func() {
-			s.allowUpdateWithExpectedHeaders(utils.Headers{"*": true})
-
-			details := brokerapi.UpdateDetails{
-				RawParameters: json.RawMessage(`{
-"insecure_origin": true,
-			"domain": "domain.gov",
-			"path": ".",
-			"headers": ["*"]
-		}`),
-			}
-			_, err := s.Broker.Update(s.ctx, "", details, true)
-
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("Should succeed when forwarding nine headers", func() {
-			s.allowUpdateWithExpectedHeaders(utils.Headers{"One": true, "Two": true, "Three": true, "Four": true, "Five": true, "Six": true, "Seven": true, "Eight": true, "Nine": true, "Host": true})
-
-			details := brokerapi.UpdateDetails{
-				RawParameters: json.RawMessage(`{
-"insecure_origin": true,
-			"domain": "domain.gov",
-			"path": ".",
-			"headers": ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine"]
-		}`),
-			}
-			_, err := s.Broker.Update(s.ctx, "", details, true)
-
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("Should error when forwarding wildcard headers and normal headers", func() {
-			s.failOnUpdateWithExpectedHeaders(utils.Headers{"*": true})
-
-			details := brokerapi.UpdateDetails{
-				RawParameters: json.RawMessage(`{
-"insecure_origin": true,
-			"domain": "domain.gov",
-			"path": ".",
-			"headers": ["*", "User-Agent"]
-		}`),
-			}
-			_, err := s.Broker.Update(s.ctx, "", details, true)
-
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(ContainSubstring("must not pass whitelisted headers alongside wildcard")))
-		})
-
-		It("Should error when forwarding ten or more headers", func() {
-			s.failOnUpdateWithExpectedHeaders(utils.Headers{"One": true, "Two": true, "Three": true, "Four": true, "Five": true, "Six": true, "Seven": true, "Eight": true, "Nine": true, "Ten": true, "Host": true})
-
-			details := brokerapi.UpdateDetails{
-				RawParameters: json.RawMessage(`{
-			"insecure_origin": true,
-			"domain": "domain.gov",
-			"path": ".",
-			"headers": ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"]
-		}`),
-			}
-			_, err := s.Broker.Update(s.ctx, "", details, true)
-
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(ContainSubstring("must not set more than 10 headers; got 11")))
-		})
+		Expect(err).To(MatchError(ContainSubstring("service no longer supports updates. please contact support")))
 	})
 })


### PR DESCRIPTION
## What

The AWS API has recently changed, requiring us to provide a field on
update that has not been provided nor required upon creation.

The field is specifically FieldLevelEncryptionID, which essentially
requires us to provide the ID of the public key, for the data to be
encrypted with.

The expectation then is that this data will be decrypted on application
side of the mix, which is not ideal scenario to be having an incident
on...

We have decided that CDN Broker have delivered enough pain to us over
the time and we're keen to deprecate it.

This doesn't come for free, and requires us to prioritise a replacement
solution to be worked on. In the mean time, we're disabling the
problematic update functionality and accept the fact we'll be handling
these as part of support responsibilities, until we have a
replacement...

Involvement: Lee Porte - TL; Mark Buckley - PM; and myself - victim.

## How to review

- Code review
- Deploy to your environment (ℹ️ I have not tested this myself)
- Create service
- Attempt to update service

Closes #31