### PR TITLE
Use existing distribution config where possible, and add empty FieldLevelEncryptionId

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -268,6 +268,20 @@ func (b *CdnServiceBroker) LastOperation(
 			State:       brokerapi.Succeeded,
 			Description: description,
 		}, nil
+	case models.Deprovisioned:
+		description := fmt.Sprintf(
+			"Service instance deprovisioned [%s => %s]; CDN domain %s",
+			route.DomainExternal, route.Origin, route.DomainInternal,
+		)
+		lsession.Info("ok", lager.Data{
+			"domain":      route.DomainExternal,
+			"state":       route.State,
+			"description": description,
+		})
+		return brokerapi.LastOperation{
+			State:       brokerapi.Succeeded,
+			Description: description,
+		}, nil
 	default:
 		description := "Service instance stuck in unmanagable state."
 		if route.CreatedAt.Before(time.Now().Add(-24 * time.Hour)) {

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -525,6 +525,18 @@ var _ = Describe("Models", func() {
 					},
 					Enabled:           aws.Bool(true),
 					ViewerCertificate: &cloudfront.ViewerCertificate{},
+					DefaultCacheBehavior: &cloudfront.DefaultCacheBehavior{
+						ForwardedValues: &cloudfront.ForwardedValues{
+							Cookies: &cloudfront.CookiePreference{
+								Forward: aws.String("all"),
+							},
+							QueryStringCacheKeys: &cloudfront.QueryStringCacheKeys{},
+						},
+						TrustedSigners: &cloudfront.TrustedSigners{},
+						AllowedMethods: &cloudfront.AllowedMethods{
+							CachedMethods: &cloudfront.CachedMethods{},
+						},
+					},
 				}
 
 				switch r.Operation.Name {
@@ -638,6 +650,18 @@ var _ = Describe("Models", func() {
 					},
 					Enabled:           aws.Bool(true),
 					ViewerCertificate: &cloudfront.ViewerCertificate{},
+					DefaultCacheBehavior: &cloudfront.DefaultCacheBehavior{
+						ForwardedValues: &cloudfront.ForwardedValues{
+							Cookies: &cloudfront.CookiePreference{
+								Forward: aws.String("all"),
+							},
+							QueryStringCacheKeys: &cloudfront.QueryStringCacheKeys{},
+						},
+						TrustedSigners: &cloudfront.TrustedSigners{},
+						AllowedMethods: &cloudfront.AllowedMethods{
+							CachedMethods: &cloudfront.CachedMethods{},
+						},
+					},
 				}
 
 				switch r.Operation.Name {
@@ -784,6 +808,18 @@ var _ = Describe("Models", func() {
 					Enabled:           aws.Bool(true),
 					ViewerCertificate: &cloudfront.ViewerCertificate{},
 					CallerReference:   aws.String("hi mom"),
+					DefaultCacheBehavior: &cloudfront.DefaultCacheBehavior{
+						ForwardedValues: &cloudfront.ForwardedValues{
+							Cookies: &cloudfront.CookiePreference{
+								Forward: aws.String("all"),
+							},
+							QueryStringCacheKeys: &cloudfront.QueryStringCacheKeys{},
+						},
+						TrustedSigners: &cloudfront.TrustedSigners{},
+						AllowedMethods: &cloudfront.AllowedMethods{
+							CachedMethods: &cloudfront.CachedMethods{},
+						},
+					},
 				}
 
 				switch r.Operation.Name {

--- a/utils/cloudfront.go
+++ b/utils/cloudfront.go
@@ -133,10 +133,11 @@ func (d *Distribution) fillDistributionConfig(config *cloudfront.DistributionCon
 					Quantity: aws.Int64(0),
 				},
 				CustomOriginConfig: &cloudfront.CustomOriginConfig{
-					HTTPPort:             aws.Int64(80),
-					HTTPSPort:            aws.Int64(443),
-					OriginReadTimeout:    aws.Int64(60),
-					OriginProtocolPolicy: getOriginProtocolPolicy(insecureOrigin),
+					HTTPPort:               aws.Int64(80),
+					HTTPSPort:              aws.Int64(443),
+					OriginReadTimeout:      aws.Int64(60),
+					OriginKeepaliveTimeout: aws.Int64(5),
+					OriginProtocolPolicy:   getOriginProtocolPolicy(insecureOrigin),
 					OriginSslProtocols: &cloudfront.OriginSslProtocols{
 						Quantity: aws.Int64(1),
 						Items: []*string{

--- a/utils/cloudfront.go
+++ b/utils/cloudfront.go
@@ -57,112 +57,21 @@ func (d *Distribution) getHeaders(headers []string) *cloudfront.Headers {
 	}
 }
 
-// fillDistributionConfig is a wrapper function that will get all the common config settings for
-// "cloudfront.DistributionConfig". This function is shared between "Create" and "Update".
-// In order to maintain backwards compatibility with older versions of the code where the callerReference was derived
-// from the domain(s), the callerReference has to be explicitly passed in. This is necessary because whenever we do an
-// update, the domains could change but we need to treat the CallerReference like an ID because
-// it can't be changed like the domains and instead the callerReference which was composed of the original domains must
-// be passed in.
-func (d *Distribution) fillDistributionConfig(config *cloudfront.DistributionConfig, origin, path string,
-	insecureOrigin bool, callerReference *string, domains []string, forwardedHeaders []string, forwardCookies bool,
-	defaultTTL int64) {
-	config.CallerReference = callerReference
+func (d *Distribution) setDistributionConfigDefaults(config *cloudfront.DistributionConfig, callerReference string) {
+	config.CallerReference = aws.String(callerReference)
 	config.Comment = aws.String("cdn route service")
 	config.Enabled = aws.Bool(true)
 	config.IsIPV6Enabled = aws.Bool(true)
+	config.PriceClass = aws.String("PriceClass_100")
+}
 
-	cookies := aws.String("all")
-	if forwardCookies == false {
-		cookies = aws.String("none")
-	}
-
-	config.DefaultCacheBehavior = &cloudfront.DefaultCacheBehavior{
-		TargetOriginId: aws.String(*callerReference),
-		ForwardedValues: &cloudfront.ForwardedValues{
-			Headers: d.getHeaders(forwardedHeaders),
-			Cookies: &cloudfront.CookiePreference{
-				Forward: cookies,
-			},
-			QueryString: aws.Bool(true),
-			QueryStringCacheKeys: &cloudfront.QueryStringCacheKeys{
-				Quantity: aws.Int64(0),
-			},
-		},
-		SmoothStreaming: aws.Bool(false),
-		DefaultTTL:      aws.Int64(defaultTTL),
-		MinTTL:          aws.Int64(0),
-		MaxTTL:          aws.Int64(31622400),
-		LambdaFunctionAssociations: &cloudfront.LambdaFunctionAssociations{
-			Quantity: aws.Int64(0),
-		},
-		TrustedSigners: &cloudfront.TrustedSigners{
-			Enabled:  aws.Bool(false),
-			Quantity: aws.Int64(0),
-		},
-		ViewerProtocolPolicy: aws.String("redirect-to-https"),
-		AllowedMethods: &cloudfront.AllowedMethods{
-			CachedMethods: &cloudfront.CachedMethods{
-				Quantity: aws.Int64(2),
-				Items: []*string{
-					aws.String("HEAD"),
-					aws.String("GET"),
-				},
-			},
-			Quantity: aws.Int64(7),
-			Items: []*string{
-				aws.String("HEAD"),
-				aws.String("GET"),
-				aws.String("OPTIONS"),
-				aws.String("PUT"),
-				aws.String("POST"),
-				aws.String("PATCH"),
-				aws.String("DELETE"),
-			},
-		},
-		Compress: aws.Bool(false),
-	}
-	config.Origins = &cloudfront.Origins{
-		Quantity: aws.Int64(2),
-		Items: []*cloudfront.Origin{
-			{
-				DomainName: aws.String(origin),
-				Id:         aws.String(*callerReference),
-				OriginPath: aws.String(path),
-				CustomHeaders: &cloudfront.CustomHeaders{
-					Quantity: aws.Int64(0),
-				},
-				CustomOriginConfig: &cloudfront.CustomOriginConfig{
-					HTTPPort:               aws.Int64(80),
-					HTTPSPort:              aws.Int64(443),
-					OriginReadTimeout:      aws.Int64(60),
-					OriginKeepaliveTimeout: aws.Int64(5),
-					OriginProtocolPolicy:   getOriginProtocolPolicy(insecureOrigin),
-					OriginSslProtocols: &cloudfront.OriginSslProtocols{
-						Quantity: aws.Int64(1),
-						Items: []*string{
-							aws.String("TLSv1.2"),
-						},
-					},
-				},
-			},
-			{
-				DomainName: aws.String(fmt.Sprintf("%s.s3.amazonaws.com", d.Settings.Bucket)),
-				Id:         aws.String(fmt.Sprintf("s3-%s-%s", d.Settings.Bucket, *callerReference)),
-				OriginPath: aws.String(""),
-				CustomHeaders: &cloudfront.CustomHeaders{
-					Quantity: aws.Int64(0),
-				},
-				S3OriginConfig: &cloudfront.S3OriginConfig{
-					OriginAccessIdentity: aws.String(""),
-				},
-			},
-		},
-	}
+func (d *Distribution) setDistributionConfigCacheBehaviors(config *cloudfront.DistributionConfig, callerReference string) {
 	config.CacheBehaviors = &cloudfront.CacheBehaviors{
 		Quantity: aws.Int64(1),
 		Items: []*cloudfront.CacheBehavior{
 			{
+				TargetOriginId:         aws.String(callerReference),
+				FieldLevelEncryptionId: aws.String(""),
 				AllowedMethods: &cloudfront.AllowedMethods{
 					CachedMethods: &cloudfront.CachedMethods{
 						Quantity: aws.Int64(2),
@@ -177,9 +86,8 @@ func (d *Distribution) fillDistributionConfig(config *cloudfront.DistributionCon
 					},
 					Quantity: aws.Int64(2),
 				},
-				Compress:       aws.Bool(false),
-				PathPattern:    aws.String("/.well-known/acme-challenge/*"),
-				TargetOriginId: aws.String(fmt.Sprintf("s3-%s-%s", d.Settings.Bucket, *callerReference)),
+				Compress:    aws.Bool(false),
+				PathPattern: aws.String("/.well-known/acme-challenge/*"),
 				ForwardedValues: &cloudfront.ForwardedValues{
 					Headers: &cloudfront.Headers{
 						Quantity: aws.Int64(0),
@@ -207,15 +115,138 @@ func (d *Distribution) fillDistributionConfig(config *cloudfront.DistributionCon
 			},
 		},
 	}
+}
+
+func (d *Distribution) setDistributionConfigOrigins(config *cloudfront.DistributionConfig, callerReference string) {
+	config.Origins = &cloudfront.Origins{
+		Quantity: aws.Int64(2),
+		Items: []*cloudfront.Origin{
+			{
+				Id: aws.String(callerReference),
+				CustomHeaders: &cloudfront.CustomHeaders{
+					Quantity: aws.Int64(0),
+				},
+				CustomOriginConfig: &cloudfront.CustomOriginConfig{
+					HTTPPort:               aws.Int64(80),
+					HTTPSPort:              aws.Int64(443),
+					OriginReadTimeout:      aws.Int64(60),
+					OriginKeepaliveTimeout: aws.Int64(5),
+					OriginSslProtocols: &cloudfront.OriginSslProtocols{
+						Quantity: aws.Int64(1),
+						Items: []*string{
+							aws.String("TLSv1.2"),
+						},
+					},
+				},
+			},
+			{
+				Id:         aws.String(fmt.Sprintf("s3-%s-%s", d.Settings.Bucket, callerReference)),
+				DomainName: aws.String(fmt.Sprintf("%s.s3.amazonaws.com", d.Settings.Bucket)),
+				OriginPath: aws.String(""),
+				CustomHeaders: &cloudfront.CustomHeaders{
+					Quantity: aws.Int64(0),
+				},
+				S3OriginConfig: &cloudfront.S3OriginConfig{
+					OriginAccessIdentity: aws.String(""),
+				},
+			},
+		},
+	}
+}
+
+func (d *Distribution) setDistributionConfigDefaultCacheBehavior(config *cloudfront.DistributionConfig, callerReference string) {
+	config.DefaultCacheBehavior.TargetOriginId = aws.String(callerReference)
+
+	config.DefaultCacheBehavior.ForwardedValues.Cookies.Forward = aws.String("all")
+	config.DefaultCacheBehavior.ForwardedValues.QueryString = aws.Bool(true)
+	config.DefaultCacheBehavior.ForwardedValues.QueryStringCacheKeys.Quantity = aws.Int64(0)
+
+	config.DefaultCacheBehavior.SmoothStreaming = aws.Bool(false)
+	config.DefaultCacheBehavior.MinTTL = aws.Int64(0)
+	config.DefaultCacheBehavior.MaxTTL = aws.Int64(31622400)
+	config.DefaultCacheBehavior.Compress = aws.Bool(false)
+
+	config.DefaultCacheBehavior.TrustedSigners.Enabled = aws.Bool(false)
+	config.DefaultCacheBehavior.TrustedSigners.Quantity = aws.Int64(0)
+
+	config.DefaultCacheBehavior.ViewerProtocolPolicy = aws.String("redirect-to-https")
+
+	config.DefaultCacheBehavior.AllowedMethods.CachedMethods.Quantity = aws.Int64(2)
+	config.DefaultCacheBehavior.AllowedMethods.CachedMethods.Items = []*string{
+		aws.String("HEAD"),
+		aws.String("GET"),
+	}
+
+	config.DefaultCacheBehavior.AllowedMethods.Quantity = aws.Int64(7)
+	config.DefaultCacheBehavior.AllowedMethods.Items = []*string{
+		aws.String("HEAD"),
+		aws.String("GET"),
+		aws.String("OPTIONS"),
+		aws.String("PUT"),
+		aws.String("POST"),
+		aws.String("PATCH"),
+		aws.String("DELETE"),
+	}
+}
+
+func (d *Distribution) configureDistributionConfig(
+	config *cloudfront.DistributionConfig,
+	domains []string,
+	origin string,
+	path string,
+	defaultTTL int64,
+	insecureOrigin bool,
+	forwardedHeaders Headers,
+	forwardCookies bool,
+) {
+	if forwardCookies == false {
+		config.DefaultCacheBehavior.ForwardedValues.Cookies.Forward = aws.String("none")
+	}
+
+	config.Origins.Items[0].DomainName = aws.String(origin)
+	config.Origins.Items[0].OriginPath = aws.String(path)
+	config.Origins.Items[0].CustomOriginConfig.OriginProtocolPolicy = getOriginProtocolPolicy(insecureOrigin)
+
 	config.Aliases = d.getAliases(domains)
-	config.PriceClass = aws.String("PriceClass_100")
+
+	config.DefaultCacheBehavior.ForwardedValues.Headers = d.getHeaders(forwardedHeaders.Strings())
+	config.DefaultCacheBehavior.DefaultTTL = aws.Int64(defaultTTL)
 }
 
 func (d *Distribution) Create(callerReference string, domains []string, origin, path string, defaultTTL int64, insecureOrigin bool, forwardedHeaders Headers, forwardCookies bool, tags map[string]string) (*cloudfront.Distribution, error) {
 	distConfig := new(cloudfront.DistributionConfig)
-	d.fillDistributionConfig(distConfig, origin, path, insecureOrigin,
-		aws.String(callerReference), domains, forwardedHeaders.Strings(), forwardCookies,
-		defaultTTL)
+
+	distConfig.DefaultCacheBehavior = &cloudfront.DefaultCacheBehavior{
+		FieldLevelEncryptionId: aws.String(""),
+		ForwardedValues: &cloudfront.ForwardedValues{
+			Cookies:              &cloudfront.CookiePreference{},
+			QueryStringCacheKeys: &cloudfront.QueryStringCacheKeys{},
+		},
+		LambdaFunctionAssociations: &cloudfront.LambdaFunctionAssociations{
+			Quantity: aws.Int64(0),
+		},
+		TrustedSigners: &cloudfront.TrustedSigners{},
+		AllowedMethods: &cloudfront.AllowedMethods{
+			CachedMethods: &cloudfront.CachedMethods{},
+		},
+	}
+
+	d.setDistributionConfigDefaults(distConfig, callerReference)
+	d.setDistributionConfigCacheBehaviors(distConfig, callerReference)
+	d.setDistributionConfigDefaultCacheBehavior(distConfig, callerReference)
+	d.setDistributionConfigOrigins(distConfig, callerReference)
+
+	d.configureDistributionConfig(
+		distConfig,
+		domains,
+		origin,
+		path,
+		defaultTTL,
+		insecureOrigin,
+		forwardedHeaders,
+		forwardCookies,
+	)
+
 	resp, err := d.Service.CreateDistributionWithTags(&cloudfront.CreateDistributionWithTagsInput{
 		DistributionConfigWithTags: &cloudfront.DistributionConfigWithTags{
 			DistributionConfig: distConfig,
@@ -238,9 +269,24 @@ func (d *Distribution) Update(distId string, domains []string, origin, path stri
 	if err != nil {
 		return nil, err
 	}
-	d.fillDistributionConfig(dist.DistributionConfig, origin, path, insecureOrigin,
-		dist.DistributionConfig.CallerReference, domains, forwardedHeaders.Strings(), forwardCookies,
-		defaultTTL)
+
+	callerReference := *dist.DistributionConfig.CallerReference
+
+	d.setDistributionConfigDefaults(dist.DistributionConfig, callerReference)
+	d.setDistributionConfigCacheBehaviors(dist.DistributionConfig, callerReference)
+	d.setDistributionConfigDefaultCacheBehavior(dist.DistributionConfig, callerReference)
+	d.setDistributionConfigOrigins(dist.DistributionConfig, callerReference)
+
+	d.configureDistributionConfig(
+		dist.DistributionConfig,
+		domains,
+		origin,
+		path,
+		defaultTTL,
+		insecureOrigin,
+		forwardedHeaders,
+		forwardCookies,
+	)
 
 	// Call the UpdateDistribution function
 	resp, err := d.Service.UpdateDistribution(&cloudfront.UpdateDistributionInput{


### PR DESCRIPTION
What
----

This is a large diff with the main goal make the code clearer (in my eyes) and fix two issues:

- Deleting a CDN distribution shouldn't fail the first time
- Updating a CDN distribution should be possible

We had a big function called `fillDistributionConfig` which was shared by Create and Update. This has been broken out into smaller helper functions for each part of the distribution config.

CloudFront also requires fields like `FieldLevelEncryptionId` and the fields mentioned in #31 (commit is cherry-picked)

Handle the state for Deprovisioned in LastOperation.

This PR doesn't fix the outstanding bug where updating one parameter (e.g. `default_ttl`) sets the others to their default values (e.g. `headers`), which will be fixed in a following PR.

How to review
----

Looking at this as one change will probably be quite difficult

I recommend going through the commits, commit by commit.

I've created and updated a new CDN route in `admin/public` of my dev env (`tlwr)`, have a look at that, maybe run `cf update-service tlwr-test-1586171064 -c '{"default_ttl": 10}'` and see that it works.

Once this has been reviewed, I'll do the bosh release and paas-cf PRs

Who can review / who worked on this
----

Anyone can review. I've cherry picked @46bit commit

Related PRs
----

I think this supersedes #31 and closes #32