### PR TITLE
Updating a distribution should not wipe existing settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,26 +91,6 @@ The easiest/recommended way to deploy the broker is via the [Concourse](http://c
     $ cf map-route <app> my.domain.gov
     ```
 
-## Custom origins
-
-If you are pointing your domain to a non-Cloud Foundry application, such as a public S3 bucket, you can pass a custom origin to the broker:
-
-```bash
-$ cf create-service cdn-route cdn-route my-cdn-route \
-    -c '{"domain": "my.domain.gov", "origin": "my-app.apps.cloud.gov"}'
-
-Create in progress. Use 'cf services' or 'cf service my-cdn-route' to check operation status.
-```
-
-If your origin is non-HTTPS, you'll need to add another parameter:
-
-```bash
-$ cf create-service cdn-route cdn-route my-cdn-route \
-    -c '{"domain": "my.domain.gov", "origin": "my-app.apps.cloud.gov", "insecure_origin": true}'
-
-Create in progress. Use 'cf services' or 'cf service my-cdn-route' to check operation status.
-```
-
 The default TTL for the CloudFront distribution is `0`. To change this, you can pass it as a parameter:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -102,15 +102,6 @@ $ cf create-service cdn-route cdn-route my-cdn-route \
 Create in progress. Use 'cf services' or 'cf service my-cdn-route' to check operation status.
 ```
 
-If you need to add a path to your origin, you can pass it in as a parameter:
-
-```bash
-$ cf create-service cdn-route cdn-route my-cdn-route \
-    -c '{"domain": "my.domain.gov", "origin": "my-app.apps.cloud.gov", "path": "/myfolder"}'
-
-Create in progress. Use 'cf services' or 'cf service my-cdn-route' to check operation status.
-```
-
 If your origin is non-HTTPS, you'll need to add another parameter:
 
 ```bash

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -20,7 +20,6 @@ import (
 
 type CreateOptions struct {
 	Domain     string   `json:"domain"`
-	Path       string   `json:"path"`
 	DefaultTTL int64    `json:"default_ttl"`
 	Cookies    bool     `json:"cookies"`
 	Headers    []string `json:"headers"`
@@ -28,7 +27,6 @@ type CreateOptions struct {
 
 type UpdateOptions struct {
 	Domain     string   `json:"domain"`
-	Path       string   `json:"path"`
 	DefaultTTL int64    `json:"default_ttl"`
 	Cookies    bool     `json:"cookies"`
 	Headers    []string `json:"headers"`
@@ -141,7 +139,6 @@ func (b *CdnServiceBroker) Provision(
 		instanceID,
 		options.Domain,
 		b.settings.DefaultOrigin,
-		options.Path,
 		options.DefaultTTL,
 		headers,
 		options.Cookies,
@@ -409,7 +406,6 @@ func (b *CdnServiceBroker) Update(
 		instanceID,
 		options.Domain,
 		b.settings.DefaultOrigin,
-		options.Path,
 		options.DefaultTTL,
 		headers, options.Cookies,
 	)

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -131,7 +131,17 @@ func (b *CdnServiceBroker) Provision(
 		"Plan":            details.PlanID,
 	}
 
-	_, err = b.manager.Create(instanceID, options.Domain, options.Origin, options.Path, options.DefaultTTL, options.InsecureOrigin, headers, options.Cookies, tags)
+	_, err = b.manager.Create(
+		instanceID,
+		options.Domain,
+		options.Origin,
+		options.Path,
+		options.DefaultTTL,
+		options.InsecureOrigin,
+		headers,
+		options.Cookies,
+		tags,
+	)
 	if err != nil {
 		lsession.Info("manager-create-err", lager.Data{
 			"options": options,

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -19,21 +19,19 @@ import (
 )
 
 type CreateOptions struct {
-	Domain         string   `json:"domain"`
-	Path           string   `json:"path"`
-	DefaultTTL     int64    `json:"default_ttl"`
-	InsecureOrigin bool     `json:"insecure_origin"`
-	Cookies        bool     `json:"cookies"`
-	Headers        []string `json:"headers"`
+	Domain     string   `json:"domain"`
+	Path       string   `json:"path"`
+	DefaultTTL int64    `json:"default_ttl"`
+	Cookies    bool     `json:"cookies"`
+	Headers    []string `json:"headers"`
 }
 
 type UpdateOptions struct {
-	Domain         string   `json:"domain"`
-	Path           string   `json:"path"`
-	DefaultTTL     int64    `json:"default_ttl"`
-	InsecureOrigin bool     `json:"insecure_origin"`
-	Cookies        bool     `json:"cookies"`
-	Headers        []string `json:"headers"`
+	Domain     string   `json:"domain"`
+	Path       string   `json:"path"`
+	DefaultTTL int64    `json:"default_ttl"`
+	Cookies    bool     `json:"cookies"`
+	Headers    []string `json:"headers"`
 }
 
 type CdnServiceBroker struct {
@@ -145,7 +143,6 @@ func (b *CdnServiceBroker) Provision(
 		b.settings.DefaultOrigin,
 		options.Path,
 		options.DefaultTTL,
-		options.InsecureOrigin,
 		headers,
 		options.Cookies,
 		tags,
@@ -414,7 +411,6 @@ func (b *CdnServiceBroker) Update(
 		b.settings.DefaultOrigin,
 		options.Path,
 		options.DefaultTTL,
-		options.InsecureOrigin,
 		headers, options.Cookies,
 	)
 	if err != nil {

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -405,7 +405,6 @@ func (b *CdnServiceBroker) Update(
 	provisioningAsync, err := b.manager.Update(
 		instanceID,
 		options.Domain,
-		b.settings.DefaultOrigin,
 		options.DefaultTTL,
 		headers, options.Cookies,
 	)

--- a/broker/broker_provision_test.go
+++ b/broker/broker_provision_test.go
@@ -33,7 +33,7 @@ type ProvisionSuite struct {
 
 func (s *ProvisionSuite) allowCreateWithExpectedHeaders(expectedHeaders utils.Headers) {
 	route := &models.Route{State: models.Provisioning}
-	s.Manager.On("Create", "123", "domain.gov", "origin.cloud.gov", "", s.settings.DefaultDefaultTTL, expectedHeaders, true,
+	s.Manager.On("Create", "123", "domain.gov", "origin.cloud.gov", s.settings.DefaultDefaultTTL, expectedHeaders, true,
 		map[string]string{
 			"Organization":    "",
 			"Space":           "",
@@ -44,7 +44,7 @@ func (s *ProvisionSuite) allowCreateWithExpectedHeaders(expectedHeaders utils.He
 }
 
 func (s *ProvisionSuite) failCreateWithExpectedHeaders(expectedHeaders utils.Headers) {
-	s.Manager.On("Create", "123", "domain.gov", "origin.cloud.gov", "", s.settings.DefaultDefaultTTL, expectedHeaders, true,
+	s.Manager.On("Create", "123", "domain.gov", "origin.cloud.gov", s.settings.DefaultDefaultTTL, expectedHeaders, true,
 		map[string]string{
 			"Organization":    "",
 			"Space":           "",
@@ -120,7 +120,7 @@ var _ = Describe("Last operation", func() {
 		s.Manager.On("Get", "123").Return(&models.Route{}, errors.New("not found"))
 		route := &models.Route{State: models.Provisioning}
 		s.cfclient.On("GetDomainByName", "domain.gov").Return(cfclient.Domain{}, nil)
-		s.Manager.On("Create", "123", "domain.gov", "origin.cloud.gov", "", s.settings.DefaultDefaultTTL, utils.Headers{"Host": true}, true,
+		s.Manager.On("Create", "123", "domain.gov", "origin.cloud.gov", s.settings.DefaultDefaultTTL, utils.Headers{"Host": true}, true,
 			map[string]string{
 				"Organization":    "",
 				"Space":           "",
@@ -141,7 +141,7 @@ var _ = Describe("Last operation", func() {
 		s.Manager.On("Get", "123").Return(&models.Route{}, errors.New("not found"))
 		route := &models.Route{State: models.Provisioning}
 		s.cfclient.On("GetDomainByName", "domain.gov").Return(cfclient.Domain{}, nil)
-		s.Manager.On("Create", "123", "domain.gov", "origin.cloud.gov", "", int64(52), utils.Headers{"Host": true}, true,
+		s.Manager.On("Create", "123", "domain.gov", "origin.cloud.gov", int64(52), utils.Headers{"Host": true}, true,
 			map[string]string{
 				"Organization":    "",
 				"Space":           "",

--- a/broker/broker_provision_test.go
+++ b/broker/broker_provision_test.go
@@ -254,7 +254,7 @@ var _ = Describe("Last operation", func() {
 			Expect(err).To(MatchError(ContainSubstring("must not pass duplicated header 'User-Agent'")))
 		})
 
-		It("Should error when forwarding wildcard headers and normal headers", func() {
+		It("Should error when specifying a specific header and also wildcard headers", func() {
 			details := brokerapi.ProvisionDetails{
 				RawParameters: []byte(`{"domain": "domain.gov", "headers": ["*", "User-Agent"]}`),
 			}

--- a/broker/broker_provision_test.go
+++ b/broker/broker_provision_test.go
@@ -161,26 +161,6 @@ var _ = Describe("Last operation", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("Should succeed with a custom origin", func() {
-		s.Manager.On("Get", "123").Return(&models.Route{}, errors.New("not found"))
-		route := &models.Route{State: models.Provisioning}
-		s.Manager.On("Create", "123", "domain.gov", "custom.cloud.gov", "", s.settings.DefaultDefaultTTL, false, utils.Headers{}, true,
-			map[string]string{
-				"Organization":    "",
-				"Space":           "",
-				"Service":         "",
-				"ServiceInstance": "123",
-				"Plan":            "",
-			}).Return(route, nil)
-
-		details := brokerapi.ProvisionDetails{
-			RawParameters: []byte(`{"domain": "domain.gov", "origin": "custom.cloud.gov"}`),
-		}
-		_, err := s.Broker.Provision(s.ctx, "123", details, true)
-
-		Expect(err).NotTo(HaveOccurred())
-	})
-
 	It("Should error when Cloud Foundry does not have the domain registered", func() {
 		s.cfclient.On("GetDomainByName", "domain.gov").Return(cfclient.Domain{}, errors.New("fail"))
 		details := brokerapi.ProvisionDetails{

--- a/broker/broker_provision_test.go
+++ b/broker/broker_provision_test.go
@@ -43,17 +43,6 @@ func (s *ProvisionSuite) allowCreateWithExpectedHeaders(expectedHeaders utils.He
 		}).Return(route, nil)
 }
 
-func (s *ProvisionSuite) failCreateWithExpectedHeaders(expectedHeaders utils.Headers) {
-	s.Manager.On("Create", "123", "domain.gov", "origin.cloud.gov", s.settings.DefaultDefaultTTL, expectedHeaders, true,
-		map[string]string{
-			"Organization":    "",
-			"Space":           "",
-			"Service":         "",
-			"ServiceInstance": "123",
-			"Plan":            "",
-		}).Return(nil, errors.New("fail"))
-}
-
 var _ = Describe("Last operation", func() {
 	var s *ProvisionSuite = &ProvisionSuite{}
 
@@ -256,8 +245,6 @@ var _ = Describe("Last operation", func() {
 		})
 
 		It("Should error when forwarding duplicate headers", func() {
-			s.failCreateWithExpectedHeaders(utils.Headers{"User-Agent": true, "Host": true})
-
 			details := brokerapi.ProvisionDetails{
 				RawParameters: []byte(`{"domain": "domain.gov", "headers": ["User-Agent", "Host", "User-Agent"]}`),
 			}
@@ -268,8 +255,6 @@ var _ = Describe("Last operation", func() {
 		})
 
 		It("Should error when forwarding wildcard headers and normal headers", func() {
-			s.failCreateWithExpectedHeaders(utils.Headers{"*": true})
-
 			details := brokerapi.ProvisionDetails{
 				RawParameters: []byte(`{"domain": "domain.gov", "headers": ["*", "User-Agent"]}`),
 			}
@@ -280,8 +265,6 @@ var _ = Describe("Last operation", func() {
 		})
 
 		It("Should error when forwarding ten or more", func() {
-			s.failCreateWithExpectedHeaders(utils.Headers{"One": true, "Two": true, "Three": true, "Four": true, "Five": true, "Six": true, "Seven": true, "Eight": true, "Nine": true, "Ten": true, "Host": true})
-
 			details := brokerapi.ProvisionDetails{
 				RawParameters: []byte(`{"domain": "domain.gov", "headers": ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"]}`),
 			}

--- a/broker/broker_provision_test.go
+++ b/broker/broker_provision_test.go
@@ -33,7 +33,7 @@ type ProvisionSuite struct {
 
 func (s *ProvisionSuite) allowCreateWithExpectedHeaders(expectedHeaders utils.Headers) {
 	route := &models.Route{State: models.Provisioning}
-	s.Manager.On("Create", "123", "domain.gov", "origin.cloud.gov", "", s.settings.DefaultDefaultTTL, false, expectedHeaders, true,
+	s.Manager.On("Create", "123", "domain.gov", "origin.cloud.gov", "", s.settings.DefaultDefaultTTL, expectedHeaders, true,
 		map[string]string{
 			"Organization":    "",
 			"Space":           "",
@@ -44,7 +44,7 @@ func (s *ProvisionSuite) allowCreateWithExpectedHeaders(expectedHeaders utils.He
 }
 
 func (s *ProvisionSuite) failCreateWithExpectedHeaders(expectedHeaders utils.Headers) {
-	s.Manager.On("Create", "123", "domain.gov", "origin.cloud.gov", "", s.settings.DefaultDefaultTTL, false, expectedHeaders, true,
+	s.Manager.On("Create", "123", "domain.gov", "origin.cloud.gov", "", s.settings.DefaultDefaultTTL, expectedHeaders, true,
 		map[string]string{
 			"Organization":    "",
 			"Space":           "",
@@ -120,7 +120,7 @@ var _ = Describe("Last operation", func() {
 		s.Manager.On("Get", "123").Return(&models.Route{}, errors.New("not found"))
 		route := &models.Route{State: models.Provisioning}
 		s.cfclient.On("GetDomainByName", "domain.gov").Return(cfclient.Domain{}, nil)
-		s.Manager.On("Create", "123", "domain.gov", "origin.cloud.gov", "", s.settings.DefaultDefaultTTL, false, utils.Headers{"Host": true}, true,
+		s.Manager.On("Create", "123", "domain.gov", "origin.cloud.gov", "", s.settings.DefaultDefaultTTL, utils.Headers{"Host": true}, true,
 			map[string]string{
 				"Organization":    "",
 				"Space":           "",
@@ -141,7 +141,7 @@ var _ = Describe("Last operation", func() {
 		s.Manager.On("Get", "123").Return(&models.Route{}, errors.New("not found"))
 		route := &models.Route{State: models.Provisioning}
 		s.cfclient.On("GetDomainByName", "domain.gov").Return(cfclient.Domain{}, nil)
-		s.Manager.On("Create", "123", "domain.gov", "origin.cloud.gov", "", int64(52), false, utils.Headers{"Host": true}, true,
+		s.Manager.On("Create", "123", "domain.gov", "origin.cloud.gov", "", int64(52), utils.Headers{"Host": true}, true,
 			map[string]string{
 				"Organization":    "",
 				"Space":           "",

--- a/broker/broker_update_test.go
+++ b/broker/broker_update_test.go
@@ -182,7 +182,7 @@ var _ = Describe("Update", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("Should error when forwarding wildcard headers and normal headers", func() {
+		It("Should error when specifying a specific header and also wildcard headers", func() {
 			details := brokerapi.UpdateDetails{
 				RawParameters: json.RawMessage(`{
 			"domain": "domain.gov",

--- a/broker/broker_update_test.go
+++ b/broker/broker_update_test.go
@@ -32,11 +32,11 @@ type UpdateSuite struct {
 }
 
 func (s *UpdateSuite) allowUpdateWithExpectedHeaders(expectedHeaders utils.Headers) {
-	s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", s.settings.DefaultDefaultTTL, expectedHeaders, true).Return(nil)
+	s.Manager.On("Update", "", "domain.gov", s.settings.DefaultDefaultTTL, expectedHeaders, true).Return(nil)
 }
 
 func (s *UpdateSuite) failOnUpdateWithExpectedHeaders(expectedHeaders utils.Headers) {
-	s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", s.settings.DefaultDefaultTTL, expectedHeaders, true).Return(errors.New("fail"))
+	s.Manager.On("Update", "", "domain.gov", s.settings.DefaultDefaultTTL, expectedHeaders, true).Return(errors.New("fail"))
 }
 
 var _ = Describe("Update", func() {
@@ -73,7 +73,7 @@ var _ = Describe("Update", func() {
 		details := brokerapi.UpdateDetails{
 			RawParameters: json.RawMessage(`{"domain": "domain.gov"}`),
 		}
-		s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", s.settings.DefaultDefaultTTL, utils.Headers{"Host": true}, true).Return(nil)
+		s.Manager.On("Update", "", "domain.gov", s.settings.DefaultDefaultTTL, utils.Headers{"Host": true}, true).Return(nil)
 		s.cfclient.On("GetDomainByName", "domain.gov").Return(cfclient.Domain{}, nil)
 		_, err := s.Broker.Update(s.ctx, "", details, true)
 
@@ -87,7 +87,7 @@ var _ = Describe("Update", func() {
 			},
 			RawParameters: json.RawMessage(`{"domain": "domain.gov"}`),
 		}
-		s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", s.settings.DefaultDefaultTTL, utils.Headers{"Host": true}, true).Return(nil)
+		s.Manager.On("Update", "", "domain.gov", s.settings.DefaultDefaultTTL, utils.Headers{"Host": true}, true).Return(nil)
 		s.cfclient.On("GetOrgByGuid", "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5").Return(cfclient.Org{Name: "my-org"}, nil)
 		s.cfclient.On("GetDomainByName", "domain.gov").Return(cfclient.Domain{}, errors.New("bad"))
 		_, err := s.Broker.Update(s.ctx, "", details, true)

--- a/broker/broker_update_test.go
+++ b/broker/broker_update_test.go
@@ -32,11 +32,11 @@ type UpdateSuite struct {
 }
 
 func (s *UpdateSuite) allowUpdateWithExpectedHeaders(expectedHeaders utils.Headers) {
-	s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", ".", s.settings.DefaultDefaultTTL, true, expectedHeaders, true).Return(nil)
+	s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", ".", s.settings.DefaultDefaultTTL, expectedHeaders, true).Return(nil)
 }
 
 func (s *UpdateSuite) failOnUpdateWithExpectedHeaders(expectedHeaders utils.Headers) {
-	s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", ".", s.settings.DefaultDefaultTTL, true, expectedHeaders, true).Return(errors.New("fail"))
+	s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", ".", s.settings.DefaultDefaultTTL, expectedHeaders, true).Return(errors.New("fail"))
 }
 
 var _ = Describe("Update", func() {
@@ -73,22 +73,21 @@ var _ = Describe("Update", func() {
 		details := brokerapi.UpdateDetails{
 			RawParameters: json.RawMessage(`{"domain": "domain.gov"}`),
 		}
-		s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", "", s.settings.DefaultDefaultTTL, false, utils.Headers{"Host": true}, true).Return(nil)
+		s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", "", s.settings.DefaultDefaultTTL, utils.Headers{"Host": true}, true).Return(nil)
 		s.cfclient.On("GetDomainByName", "domain.gov").Return(cfclient.Domain{}, nil)
 		_, err := s.Broker.Update(s.ctx, "", details, true)
 
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("Should succeed when given origin and path and insecure_origin", func() {
+	It("Should succeed when given path", func() {
 		details := brokerapi.UpdateDetails{
 			RawParameters: json.RawMessage(`{
-				"insecure_origin": true,
 				"domain": "domain.gov",
 				"path": "."
 			}`),
 		}
-		s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", ".", s.settings.DefaultDefaultTTL, true, utils.Headers{"Host": true}, true).Return(nil)
+		s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", ".", s.settings.DefaultDefaultTTL, utils.Headers{"Host": true}, true).Return(nil)
 		s.cfclient.On("GetDomainByName", "domain.gov").Return(cfclient.Domain{}, nil)
 		_, err := s.Broker.Update(s.ctx, "", details, true)
 
@@ -102,7 +101,7 @@ var _ = Describe("Update", func() {
 			},
 			RawParameters: json.RawMessage(`{"domain": "domain.gov"}`),
 		}
-		s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", ".", true, utils.Headers{"Host": true}, true).Return(nil)
+		s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", ".", utils.Headers{"Host": true}, true).Return(nil)
 		s.cfclient.On("GetOrgByGuid", "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5").Return(cfclient.Org{Name: "my-org"}, nil)
 		s.cfclient.On("GetDomainByName", "domain.gov").Return(cfclient.Domain{}, errors.New("bad"))
 		_, err := s.Broker.Update(s.ctx, "", details, true)

--- a/broker/broker_update_test.go
+++ b/broker/broker_update_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Update", func() {
 		s.cfclient = cfmock.Client{}
 		s.logger = lager.NewLogger("test")
 		s.settings = config.Settings{
-			DefaultOrigin: "origin.cloud.gov",
+			DefaultOrigin:     "origin.cloud.gov",
 			DefaultDefaultTTL: int64(0),
 		}
 		s.Broker = broker.New(
@@ -61,12 +61,12 @@ var _ = Describe("Update", func() {
 
 	It("Should error when not given options", func() {
 		details := brokerapi.UpdateDetails{
-			RawParameters: json.RawMessage(`{"origin": ""}`),
+			RawParameters: json.RawMessage(`{}`),
 		}
 		_, err := s.Broker.Update(s.ctx, "", details, true)
 
 		Expect(err).To(HaveOccurred())
-		Expect(err).To(MatchError(ContainSubstring("must pass non-empty `domain` or `origin`")))
+		Expect(err).To(MatchError(ContainSubstring("must pass non-empty `domain`")))
 	})
 
 	It("Should succeed when given only a domain", func() {
@@ -74,17 +74,6 @@ var _ = Describe("Update", func() {
 			RawParameters: json.RawMessage(`{"domain": "domain.gov"}`),
 		}
 		s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", "", s.settings.DefaultDefaultTTL, false, utils.Headers{"Host": true}, true).Return(nil)
-		s.cfclient.On("GetDomainByName", "domain.gov").Return(cfclient.Domain{}, nil)
-		_, err := s.Broker.Update(s.ctx, "", details, true)
-
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("Should succeed when given only an origin", func() {
-		details := brokerapi.UpdateDetails{
-			RawParameters: json.RawMessage(`{"origin": "origin.gov"}`),
-		}
-		s.Manager.On("Update", "", "", "origin.gov", "", s.settings.DefaultDefaultTTL, false, utils.Headers{}, true).Return(nil)
 		s.cfclient.On("GetDomainByName", "domain.gov").Return(cfclient.Domain{}, nil)
 		_, err := s.Broker.Update(s.ctx, "", details, true)
 

--- a/broker/broker_update_test.go
+++ b/broker/broker_update_test.go
@@ -32,11 +32,11 @@ type UpdateSuite struct {
 }
 
 func (s *UpdateSuite) allowUpdateWithExpectedHeaders(expectedHeaders utils.Headers) {
-	s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", ".", s.settings.DefaultDefaultTTL, expectedHeaders, true).Return(nil)
+	s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", s.settings.DefaultDefaultTTL, expectedHeaders, true).Return(nil)
 }
 
 func (s *UpdateSuite) failOnUpdateWithExpectedHeaders(expectedHeaders utils.Headers) {
-	s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", ".", s.settings.DefaultDefaultTTL, expectedHeaders, true).Return(errors.New("fail"))
+	s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", s.settings.DefaultDefaultTTL, expectedHeaders, true).Return(errors.New("fail"))
 }
 
 var _ = Describe("Update", func() {
@@ -73,21 +73,7 @@ var _ = Describe("Update", func() {
 		details := brokerapi.UpdateDetails{
 			RawParameters: json.RawMessage(`{"domain": "domain.gov"}`),
 		}
-		s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", "", s.settings.DefaultDefaultTTL, utils.Headers{"Host": true}, true).Return(nil)
-		s.cfclient.On("GetDomainByName", "domain.gov").Return(cfclient.Domain{}, nil)
-		_, err := s.Broker.Update(s.ctx, "", details, true)
-
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("Should succeed when given path", func() {
-		details := brokerapi.UpdateDetails{
-			RawParameters: json.RawMessage(`{
-				"domain": "domain.gov",
-				"path": "."
-			}`),
-		}
-		s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", ".", s.settings.DefaultDefaultTTL, utils.Headers{"Host": true}, true).Return(nil)
+		s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", s.settings.DefaultDefaultTTL, utils.Headers{"Host": true}, true).Return(nil)
 		s.cfclient.On("GetDomainByName", "domain.gov").Return(cfclient.Domain{}, nil)
 		_, err := s.Broker.Update(s.ctx, "", details, true)
 
@@ -101,7 +87,7 @@ var _ = Describe("Update", func() {
 			},
 			RawParameters: json.RawMessage(`{"domain": "domain.gov"}`),
 		}
-		s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", ".", utils.Headers{"Host": true}, true).Return(nil)
+		s.Manager.On("Update", "", "domain.gov", "origin.cloud.gov", s.settings.DefaultDefaultTTL, utils.Headers{"Host": true}, true).Return(nil)
 		s.cfclient.On("GetOrgByGuid", "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5").Return(cfclient.Org{Name: "my-org"}, nil)
 		s.cfclient.On("GetDomainByName", "domain.gov").Return(cfclient.Domain{}, errors.New("bad"))
 		_, err := s.Broker.Update(s.ctx, "", details, true)
@@ -122,7 +108,6 @@ var _ = Describe("Update", func() {
 				RawParameters: json.RawMessage(`{
 			"insecure_origin": true,
 			"domain": "domain.gov",
-			"path": ".",
 			"headers": ["Host"]
 		}`),
 			}
@@ -138,7 +123,6 @@ var _ = Describe("Update", func() {
 				RawParameters: json.RawMessage(`{
 "insecure_origin": true,
 			"domain": "domain.gov",
-			"path": ".",
 			"headers": ["User-Agent"]
 		}`),
 			}
@@ -154,7 +138,6 @@ var _ = Describe("Update", func() {
 				RawParameters: json.RawMessage(`{
 "insecure_origin": true,
 			"domain": "domain.gov",
-			"path": ".",
 			"headers": ["*"]
 		}`),
 			}
@@ -170,7 +153,6 @@ var _ = Describe("Update", func() {
 				RawParameters: json.RawMessage(`{
 "insecure_origin": true,
 			"domain": "domain.gov",
-			"path": ".",
 			"headers": ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine"]
 		}`),
 			}
@@ -186,7 +168,6 @@ var _ = Describe("Update", func() {
 				RawParameters: json.RawMessage(`{
 "insecure_origin": true,
 			"domain": "domain.gov",
-			"path": ".",
 			"headers": ["*", "User-Agent"]
 		}`),
 			}
@@ -203,7 +184,6 @@ var _ = Describe("Update", func() {
 				RawParameters: json.RawMessage(`{
 			"insecure_origin": true,
 			"domain": "domain.gov",
-			"path": ".",
 			"headers": ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"]
 		}`),
 			}

--- a/models/mocks/RouteManagerIface.go
+++ b/models/mocks/RouteManagerIface.go
@@ -133,11 +133,11 @@ func (_m *RouteManagerIface) RenewAll() {
 }
 
 // Update provides a mock function with given fields: instanceId, domain, forwardedHeaders, forwardCookies
-func (_m *RouteManagerIface) Update(instanceId string, domain string, defaultTTL int64, forwardedHeaders utils.Headers, forwardCookies bool) (bool, error) {
+func (_m *RouteManagerIface) Update(instanceId string, domain *string, defaultTTL *int64, forwardedHeaders *utils.Headers, forwardCookies *bool) (bool, error) {
 	ret := _m.Called(instanceId, domain, defaultTTL, forwardedHeaders, forwardCookies)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, int64, utils.Headers, bool) error); ok {
+	if rf, ok := ret.Get(0).(func(string, *string, *int64, *utils.Headers, *bool) error); ok {
 		r0 = rf(instanceId, domain, defaultTTL, forwardedHeaders, forwardCookies)
 	} else {
 		r0 = ret.Error(0)

--- a/models/mocks/RouteManagerIface.go
+++ b/models/mocks/RouteManagerIface.go
@@ -132,13 +132,13 @@ func (_m *RouteManagerIface) RenewAll() {
 	_m.Called()
 }
 
-// Update provides a mock function with given fields: instanceId, domain, origin, forwardedHeaders, forwardCookies
-func (_m *RouteManagerIface) Update(instanceId string, domain string, origin string, defaultTTL int64, forwardedHeaders utils.Headers, forwardCookies bool) (bool, error) {
-	ret := _m.Called(instanceId, domain, origin, defaultTTL, forwardedHeaders, forwardCookies)
+// Update provides a mock function with given fields: instanceId, domain, forwardedHeaders, forwardCookies
+func (_m *RouteManagerIface) Update(instanceId string, domain string, defaultTTL int64, forwardedHeaders utils.Headers, forwardCookies bool) (bool, error) {
+	ret := _m.Called(instanceId, domain, defaultTTL, forwardedHeaders, forwardCookies)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string, int64, utils.Headers, bool) error); ok {
-		r0 = rf(instanceId, domain, origin, defaultTTL, forwardedHeaders, forwardCookies)
+	if rf, ok := ret.Get(0).(func(string, string, int64, utils.Headers, bool) error); ok {
+		r0 = rf(instanceId, domain, defaultTTL, forwardedHeaders, forwardCookies)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/models/mocks/RouteManagerIface.go
+++ b/models/mocks/RouteManagerIface.go
@@ -11,13 +11,13 @@ type RouteManagerIface struct {
 	mock.Mock
 }
 
-// Create provides a mock function with given fields: instanceId, domain, origin, path, defaultTTL,  forwardedHeaders, forwardCookies, tags
-func (_m *RouteManagerIface) Create(instanceId string, domain string, origin string, path string, defaultTTL int64, forwardedHeaders utils.Headers, forwardCookies bool, tags map[string]string) (*models.Route, error) {
-	ret := _m.Called(instanceId, domain, origin, path, defaultTTL, forwardedHeaders, forwardCookies, tags)
+// Create provides a mock function with given fields: instanceId, domain, origin, defaultTTL,  forwardedHeaders, forwardCookies, tags
+func (_m *RouteManagerIface) Create(instanceId string, domain string, origin string, defaultTTL int64, forwardedHeaders utils.Headers, forwardCookies bool, tags map[string]string) (*models.Route, error) {
+	ret := _m.Called(instanceId, domain, origin, defaultTTL, forwardedHeaders, forwardCookies, tags)
 
 	var r0 *models.Route
-	if rf, ok := ret.Get(0).(func(string, string, string, string, int64, utils.Headers, bool, map[string]string) *models.Route); ok {
-		r0 = rf(instanceId, domain, origin, path, defaultTTL, forwardedHeaders, forwardCookies, tags)
+	if rf, ok := ret.Get(0).(func(string, string, string, int64, utils.Headers, bool, map[string]string) *models.Route); ok {
+		r0 = rf(instanceId, domain, origin, defaultTTL, forwardedHeaders, forwardCookies, tags)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.Route)
@@ -25,8 +25,8 @@ func (_m *RouteManagerIface) Create(instanceId string, domain string, origin str
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string, string, string, int64, utils.Headers, bool, map[string]string) error); ok {
-		r1 = rf(instanceId, domain, origin, path, defaultTTL, forwardedHeaders, forwardCookies, tags)
+	if rf, ok := ret.Get(1).(func(string, string, string, int64, utils.Headers, bool, map[string]string) error); ok {
+		r1 = rf(instanceId, domain, origin, defaultTTL, forwardedHeaders, forwardCookies, tags)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -132,13 +132,13 @@ func (_m *RouteManagerIface) RenewAll() {
 	_m.Called()
 }
 
-// Update provides a mock function with given fields: instanceId, domain, origin, path, forwardedHeaders, forwardCookies
-func (_m *RouteManagerIface) Update(instanceId string, domain string, origin string, path string, defaultTTL int64, forwardedHeaders utils.Headers, forwardCookies bool) (bool, error) {
-	ret := _m.Called(instanceId, domain, origin, path, defaultTTL, forwardedHeaders, forwardCookies)
+// Update provides a mock function with given fields: instanceId, domain, origin, forwardedHeaders, forwardCookies
+func (_m *RouteManagerIface) Update(instanceId string, domain string, origin string, defaultTTL int64, forwardedHeaders utils.Headers, forwardCookies bool) (bool, error) {
+	ret := _m.Called(instanceId, domain, origin, defaultTTL, forwardedHeaders, forwardCookies)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string, string, int64, utils.Headers, bool) error); ok {
-		r0 = rf(instanceId, domain, origin, path, defaultTTL, forwardedHeaders, forwardCookies)
+	if rf, ok := ret.Get(0).(func(string, string, string, int64, utils.Headers, bool) error); ok {
+		r0 = rf(instanceId, domain, origin, defaultTTL, forwardedHeaders, forwardCookies)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/models/mocks/RouteManagerIface.go
+++ b/models/mocks/RouteManagerIface.go
@@ -11,13 +11,13 @@ type RouteManagerIface struct {
 	mock.Mock
 }
 
-// Create provides a mock function with given fields: instanceId, domain, origin, path, defaultTTL,  insecureOrigin, forwardedHeaders, forwardCookies, tags
-func (_m *RouteManagerIface) Create(instanceId string, domain string, origin string, path string, defaultTTL int64, insecureOrigin bool, forwardedHeaders utils.Headers, forwardCookies bool, tags map[string]string) (*models.Route, error) {
-	ret := _m.Called(instanceId, domain, origin, path,  defaultTTL,  insecureOrigin, forwardedHeaders, forwardCookies, tags)
+// Create provides a mock function with given fields: instanceId, domain, origin, path, defaultTTL,  forwardedHeaders, forwardCookies, tags
+func (_m *RouteManagerIface) Create(instanceId string, domain string, origin string, path string, defaultTTL int64, forwardedHeaders utils.Headers, forwardCookies bool, tags map[string]string) (*models.Route, error) {
+	ret := _m.Called(instanceId, domain, origin, path, defaultTTL, forwardedHeaders, forwardCookies, tags)
 
 	var r0 *models.Route
-	if rf, ok := ret.Get(0).(func(string, string, string, string, int64, bool, utils.Headers, bool, map[string]string) *models.Route); ok {
-		r0 = rf(instanceId, domain, origin, path, defaultTTL,  insecureOrigin, forwardedHeaders, forwardCookies, tags)
+	if rf, ok := ret.Get(0).(func(string, string, string, string, int64, utils.Headers, bool, map[string]string) *models.Route); ok {
+		r0 = rf(instanceId, domain, origin, path, defaultTTL, forwardedHeaders, forwardCookies, tags)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.Route)
@@ -25,8 +25,8 @@ func (_m *RouteManagerIface) Create(instanceId string, domain string, origin str
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string, string, string, int64, bool, utils.Headers, bool, map[string]string) error); ok {
-		r1 = rf(instanceId, domain, origin, path, defaultTTL,  insecureOrigin, forwardedHeaders, forwardCookies, tags)
+	if rf, ok := ret.Get(1).(func(string, string, string, string, int64, utils.Headers, bool, map[string]string) error); ok {
+		r1 = rf(instanceId, domain, origin, path, defaultTTL, forwardedHeaders, forwardCookies, tags)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -132,13 +132,13 @@ func (_m *RouteManagerIface) RenewAll() {
 	_m.Called()
 }
 
-// Update provides a mock function with given fields: instanceId, domain, origin, path, insecureOrigin, forwardedHeaders, forwardCookies
-func (_m *RouteManagerIface) Update(instanceId string, domain string, origin string, path string, defaultTTL int64, insecureOrigin bool, forwardedHeaders utils.Headers, forwardCookies bool) (bool, error) {
-	ret := _m.Called(instanceId, domain, origin, path, defaultTTL,  insecureOrigin, forwardedHeaders, forwardCookies)
+// Update provides a mock function with given fields: instanceId, domain, origin, path, forwardedHeaders, forwardCookies
+func (_m *RouteManagerIface) Update(instanceId string, domain string, origin string, path string, defaultTTL int64, forwardedHeaders utils.Headers, forwardCookies bool) (bool, error) {
+	ret := _m.Called(instanceId, domain, origin, path, defaultTTL, forwardedHeaders, forwardCookies)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string, string, int64, bool, utils.Headers, bool) error); ok {
-		r0 = rf(instanceId, domain, origin, path, defaultTTL,  insecureOrigin, forwardedHeaders, forwardCookies)
+	if rf, ok := ret.Get(0).(func(string, string, string, string, int64, utils.Headers, bool) error); ok {
+		r0 = rf(instanceId, domain, origin, path, defaultTTL, forwardedHeaders, forwardCookies)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/models/models.go
+++ b/models/models.go
@@ -227,7 +227,6 @@ type RouteManagerIface interface {
 	Update(
 		instanceId string,
 		domain string,
-		origin string,
 		defaultTTL int64,
 		forwardedHeaders utils.Headers,
 		forwardCookies bool,
@@ -381,7 +380,6 @@ func (m *RouteManager) Get(instanceId string) (*Route, error) {
 func (m *RouteManager) Update(
 	instanceId string,
 	domain string,
-	origin string,
 	defaultTTL int64,
 	forwardedHeaders utils.Headers,
 	forwardCookies bool,
@@ -409,10 +407,6 @@ func (m *RouteManager) Update(
 	if domain != "" {
 		lsession.Info("param-update-domain")
 		route.DomainExternal = domain
-	}
-	if origin != "" {
-		lsession.Info("param-update-origin")
-		route.Origin = origin
 	}
 	if defaultTTL != route.DefaultTTL {
 		lsession.Info("param-update-default-ttl")

--- a/models/models.go
+++ b/models/models.go
@@ -215,9 +215,9 @@ type Certificate struct {
 
 type RouteManagerIface interface {
 	Create(
-		instanceId,
-		domain,
-		origin,
+		instanceId string,
+		domain string,
+		origin string,
 		path string,
 		defaultTTL int64,
 		insecureOrigin bool,
@@ -228,7 +228,7 @@ type RouteManagerIface interface {
 
 	Update(
 		instanceId string,
-		domain,
+		domain string,
 		origin string,
 		path string,
 		defaultTTL int64,
@@ -387,7 +387,7 @@ func (m *RouteManager) Get(instanceId string) (*Route, error) {
 // Update updates the CDN route service and returns whether the update has been
 // performed asynchronously or not
 func (m *RouteManager) Update(
-	instanceId,
+	instanceId string,
 	domain,
 	origin string,
 	path string,

--- a/models/models.go
+++ b/models/models.go
@@ -183,7 +183,7 @@ type Route struct {
 	DistId         string
 	Origin         string
 	Path           string
-	InsecureOrigin bool
+	InsecureOrigin bool // Always false, should not remove because it is in DB
 	Certificate    Certificate
 	UserData       UserData
 	UserDataID     int
@@ -220,7 +220,6 @@ type RouteManagerIface interface {
 		origin string,
 		path string,
 		defaultTTL int64,
-		insecureOrigin bool,
 		forwardedHeaders utils.Headers,
 		forwardCookies bool,
 		tags map[string]string,
@@ -232,7 +231,6 @@ type RouteManagerIface interface {
 		origin string,
 		path string,
 		defaultTTL int64,
-		insecureOrigin bool,
 		forwardedHeaders utils.Headers,
 		forwardCookies bool,
 	) (bool, error)
@@ -285,7 +283,6 @@ func (m *RouteManager) Create(
 	origin,
 	path string,
 	defaultTTL int64,
-	insecureOrigin bool,
 	forwardedHeaders utils.Headers,
 	forwardCookies bool,
 	tags map[string]string,
@@ -298,7 +295,7 @@ func (m *RouteManager) Create(
 		Origin:         origin,
 		Path:           path,
 		DefaultTTL:     defaultTTL,
-		InsecureOrigin: insecureOrigin,
+		InsecureOrigin: false,
 	}
 
 	lsession := m.logger.Session("route-manager-create-route", lager.Data{
@@ -341,7 +338,6 @@ func (m *RouteManager) Create(
 		origin,
 		path,
 		defaultTTL,
-		insecureOrigin,
 		forwardedHeaders,
 		forwardCookies,
 		tags,
@@ -392,7 +388,6 @@ func (m *RouteManager) Update(
 	origin string,
 	path string,
 	defaultTTL int64,
-	insecureOrigin bool,
 	forwardedHeaders utils.Headers,
 	forwardCookies bool,
 ) (bool, error) {
@@ -432,10 +427,6 @@ func (m *RouteManager) Update(
 		lsession.Info("param-update-default-ttl")
 		route.DefaultTTL = defaultTTL
 	}
-	if insecureOrigin != route.InsecureOrigin {
-		lsession.Info("param-update-insecure-origin")
-		route.InsecureOrigin = insecureOrigin
-	}
 
 	// Update the distribution
 	lsession.Info("cloudfront-update-excluding-domains")
@@ -444,7 +435,6 @@ func (m *RouteManager) Update(
 		oldDomainsForCloudFront,
 		route.Origin, route.Path,
 		route.DefaultTTL,
-		route.InsecureOrigin,
 		forwardedHeaders, forwardCookies,
 	)
 	if err != nil {

--- a/models/models.go
+++ b/models/models.go
@@ -182,8 +182,8 @@ type Route struct {
 	DomainInternal string
 	DistId         string
 	Origin         string
-	Path           string
-	InsecureOrigin bool // Always false, should not remove because it is in DB
+	Path           string // Always empty, should not remove because it is in DB
+	InsecureOrigin bool   // Always false, should not remove because it is in DB
 	Certificate    Certificate
 	UserData       UserData
 	UserDataID     int
@@ -218,7 +218,6 @@ type RouteManagerIface interface {
 		instanceId string,
 		domain string,
 		origin string,
-		path string,
 		defaultTTL int64,
 		forwardedHeaders utils.Headers,
 		forwardCookies bool,
@@ -229,7 +228,6 @@ type RouteManagerIface interface {
 		instanceId string,
 		domain string,
 		origin string,
-		path string,
 		defaultTTL int64,
 		forwardedHeaders utils.Headers,
 		forwardCookies bool,
@@ -279,9 +277,8 @@ func NewManager(
 
 func (m *RouteManager) Create(
 	instanceId,
-	domain,
-	origin,
-	path string,
+	domain string,
+	origin string,
 	defaultTTL int64,
 	forwardedHeaders utils.Headers,
 	forwardCookies bool,
@@ -293,7 +290,7 @@ func (m *RouteManager) Create(
 		State:          Provisioning,
 		DomainExternal: domain,
 		Origin:         origin,
-		Path:           path,
+		Path:           "",
 		DefaultTTL:     defaultTTL,
 		InsecureOrigin: false,
 	}
@@ -336,7 +333,6 @@ func (m *RouteManager) Create(
 		instanceId,
 		make([]string, 0),
 		origin,
-		path,
 		defaultTTL,
 		forwardedHeaders,
 		forwardCookies,
@@ -384,9 +380,8 @@ func (m *RouteManager) Get(instanceId string) (*Route, error) {
 // performed asynchronously or not
 func (m *RouteManager) Update(
 	instanceId string,
-	domain,
+	domain string,
 	origin string,
-	path string,
 	defaultTTL int64,
 	forwardedHeaders utils.Headers,
 	forwardCookies bool,
@@ -419,10 +414,6 @@ func (m *RouteManager) Update(
 		lsession.Info("param-update-origin")
 		route.Origin = origin
 	}
-	if path != route.Path {
-		lsession.Info("param-update-path")
-		route.Path = path
-	}
 	if defaultTTL != route.DefaultTTL {
 		lsession.Info("param-update-default-ttl")
 		route.DefaultTTL = defaultTTL
@@ -433,7 +424,7 @@ func (m *RouteManager) Update(
 	dist, err := m.cloudFront.Update(
 		route.DistId,
 		oldDomainsForCloudFront,
-		route.Origin, route.Path,
+		route.Origin,
 		route.DefaultTTL,
 		forwardedHeaders, forwardCookies,
 	)

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -930,7 +930,6 @@ var _ = Describe("Models", func() {
 			performedAsynchronously, err := manager.Update(
 				cloudfrontDistID,
 				brokerAPICallDomainArgument,
-				origin,
 				defaultTTL,
 				forwardedHeaders,
 				forwardCookies,
@@ -1031,7 +1030,6 @@ var _ = Describe("Models", func() {
 			performedAsynchronously, err := manager.Update(
 				cloudfrontDistID,
 				brokerAPICallDomainArgument,
-				origin,
 				defaultTTL,
 				forwardedHeaders,
 				forwardCookies,

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -436,7 +436,6 @@ var _ = Describe("Models", func() {
 			instanceID := "cloudfoundry-instance-id"
 			domain := "foo.paas.gov.uk"
 			origin := "foo.cloudapps.digital"
-			path := "/"
 			defaultTTL := int64(0)
 			forwardedHeaders := utils.Headers{}
 			forwardCookies := false
@@ -485,7 +484,7 @@ var _ = Describe("Models", func() {
 			)
 
 			_, err := manager.Create(
-				instanceID, domain, origin, path, defaultTTL,
+				instanceID, domain, origin, defaultTTL,
 				forwardedHeaders, forwardCookies, tags,
 			)
 			Expect(acmeProviderMock.GetHTTP01ClientCallCount()).To(
@@ -507,7 +506,6 @@ var _ = Describe("Models", func() {
 			instanceID := "cloudfoundry-instance-id"
 			domain := "foo.paas.gov.uk"
 			origin := "foo.cloudapps.digital"
-			path := "/"
 			defaultTTL := int64(0)
 
 			settings, _ := config.NewSettings()
@@ -586,7 +584,7 @@ var _ = Describe("Models", func() {
 				State:          models.Provisioning,
 				DomainExternal: domain,
 				Origin:         origin,
-				Path:           path,
+				Path:           "",
 				DefaultTTL:     defaultTTL,
 				InsecureOrigin: false,
 			}
@@ -693,7 +691,6 @@ var _ = Describe("Models", func() {
 			instanceID := "cloudfoundry-instance-id"
 			domain := "foo.paas.gov.uk"
 			origin := "foo.cloudapps.digital"
-			path := "/"
 			defaultTTL := int64(0)
 
 			settings, _ := config.NewSettings()
@@ -721,7 +718,7 @@ var _ = Describe("Models", func() {
 				State:          models.Provisioning,
 				DomainExternal: domain,
 				Origin:         origin,
-				Path:           path,
+				Path:           "",
 				DefaultTTL:     defaultTTL,
 				InsecureOrigin: false,
 			}
@@ -766,7 +763,6 @@ var _ = Describe("Models", func() {
 			cloudfrontDistID = "cloudfoundry-instance-id"
 			domain           = "foo.paas.gov.uk"
 			origin           = "foo.cloudapps.digital"
-			path             = "/"
 			defaultTTL       = int64(0)
 			forwardedHeaders = utils.Headers{"X-Forwarded-Five": true}
 			forwardCookies   = false
@@ -892,7 +888,7 @@ var _ = Describe("Models", func() {
 					time.Now(), time.Now(), nil,
 					routeID, "[]",
 					domain, "foo.cloudfront.net",
-					cloudfrontDistID, origin, path,
+					cloudfrontDistID, origin, "",
 					defaultTTL, false, certificateID,
 					userDataID, "Provisioned",
 				),
@@ -935,7 +931,6 @@ var _ = Describe("Models", func() {
 				cloudfrontDistID,
 				brokerAPICallDomainArgument,
 				origin,
-				path,
 				defaultTTL,
 				forwardedHeaders,
 				forwardCookies,
@@ -994,7 +989,7 @@ var _ = Describe("Models", func() {
 					time.Now(), time.Now(), nil,
 					routeID, "[]",
 					domain, "foo.cloudfront.net",
-					cloudfrontDistID, origin, path,
+					cloudfrontDistID, origin, "",
 					defaultTTL, false, certificateID,
 					userDataID, "Provisioned",
 				),
@@ -1037,7 +1032,6 @@ var _ = Describe("Models", func() {
 				cloudfrontDistID,
 				brokerAPICallDomainArgument,
 				origin,
-				path,
 				defaultTTL,
 				forwardedHeaders,
 				forwardCookies,

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -438,7 +438,6 @@ var _ = Describe("Models", func() {
 			origin := "foo.cloudapps.digital"
 			path := "/"
 			defaultTTL := int64(0)
-			insecureOrigin := false
 			forwardedHeaders := utils.Headers{}
 			forwardCookies := false
 			tags := map[string]string{}
@@ -487,7 +486,7 @@ var _ = Describe("Models", func() {
 
 			_, err := manager.Create(
 				instanceID, domain, origin, path, defaultTTL,
-				insecureOrigin, forwardedHeaders, forwardCookies, tags,
+				forwardedHeaders, forwardCookies, tags,
 			)
 			Expect(acmeProviderMock.GetHTTP01ClientCallCount()).To(
 				Equal(0), "Creating a CDN service should never use HTTP challenges",
@@ -510,7 +509,6 @@ var _ = Describe("Models", func() {
 			origin := "foo.cloudapps.digital"
 			path := "/"
 			defaultTTL := int64(0)
-			insecureOrigin := false
 
 			settings, _ := config.NewSettings()
 			awsSession := session.New(nil)
@@ -590,7 +588,7 @@ var _ = Describe("Models", func() {
 				Origin:         origin,
 				Path:           path,
 				DefaultTTL:     defaultTTL,
-				InsecureOrigin: insecureOrigin,
+				InsecureOrigin: false,
 			}
 
 			rsaTestKey, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -697,7 +695,6 @@ var _ = Describe("Models", func() {
 			origin := "foo.cloudapps.digital"
 			path := "/"
 			defaultTTL := int64(0)
-			insecureOrigin := false
 
 			settings, _ := config.NewSettings()
 			awsSession := session.New(nil)
@@ -726,7 +723,7 @@ var _ = Describe("Models", func() {
 				Origin:         origin,
 				Path:           path,
 				DefaultTTL:     defaultTTL,
-				InsecureOrigin: insecureOrigin,
+				InsecureOrigin: false,
 			}
 		})
 
@@ -771,7 +768,6 @@ var _ = Describe("Models", func() {
 			origin           = "foo.cloudapps.digital"
 			path             = "/"
 			defaultTTL       = int64(0)
-			insecureOrigin   = false
 			forwardedHeaders = utils.Headers{"X-Forwarded-Five": true}
 			forwardCookies   = false
 
@@ -941,7 +937,6 @@ var _ = Describe("Models", func() {
 				origin,
 				path,
 				defaultTTL,
-				insecureOrigin,
 				forwardedHeaders,
 				forwardCookies,
 			)
@@ -1044,7 +1039,6 @@ var _ = Describe("Models", func() {
 				origin,
 				path,
 				defaultTTL,
-				insecureOrigin,
 				forwardedHeaders,
 				forwardCookies,
 			)

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -929,10 +929,10 @@ var _ = Describe("Models", func() {
 
 			performedAsynchronously, err := manager.Update(
 				cloudfrontDistID,
-				brokerAPICallDomainArgument,
-				defaultTTL,
-				forwardedHeaders,
-				forwardCookies,
+				&brokerAPICallDomainArgument,
+				&defaultTTL,
+				&forwardedHeaders,
+				&forwardCookies,
 			)
 
 			Expect(err).NotTo(HaveOccurred())
@@ -1029,10 +1029,10 @@ var _ = Describe("Models", func() {
 
 			performedAsynchronously, err := manager.Update(
 				cloudfrontDistID,
-				brokerAPICallDomainArgument,
-				defaultTTL,
-				forwardedHeaders,
-				forwardCookies,
+				&brokerAPICallDomainArgument,
+				&defaultTTL,
+				&forwardedHeaders,
+				&forwardCookies,
 			)
 
 			Expect(err).NotTo(HaveOccurred())

--- a/utils/cloudfront.go
+++ b/utils/cloudfront.go
@@ -10,8 +10,8 @@ import (
 )
 
 type DistributionIface interface {
-	Create(callerReference string, domains []string, origin, path string, defaultTTL int64, forwardedHeaders Headers, forwardCookies bool, tags map[string]string) (*cloudfront.Distribution, error)
-	Update(distId string, domains []string, origin, path string, defaultTTL int64, forwardedHeaders Headers, forwardCookies bool) (*cloudfront.Distribution, error)
+	Create(callerReference string, domains []string, origin string, defaultTTL int64, forwardedHeaders Headers, forwardCookies bool, tags map[string]string) (*cloudfront.Distribution, error)
+	Update(distId string, domains []string, origin string, defaultTTL int64, forwardedHeaders Headers, forwardCookies bool) (*cloudfront.Distribution, error)
 	Get(distId string) (*cloudfront.Distribution, error)
 	SetCertificateAndCname(distId, certId string, domains []string) error
 	Disable(distId string) error
@@ -193,7 +193,6 @@ func (d *Distribution) configureDistributionConfig(
 	config *cloudfront.DistributionConfig,
 	domains []string,
 	origin string,
-	path string,
 	defaultTTL int64,
 	forwardedHeaders Headers,
 	forwardCookies bool,
@@ -203,7 +202,6 @@ func (d *Distribution) configureDistributionConfig(
 	}
 
 	config.Origins.Items[0].DomainName = aws.String(origin)
-	config.Origins.Items[0].OriginPath = aws.String(path)
 	config.Origins.Items[0].CustomOriginConfig.OriginProtocolPolicy = aws.String("https-only")
 
 	config.Aliases = d.getAliases(domains)
@@ -212,7 +210,7 @@ func (d *Distribution) configureDistributionConfig(
 	config.DefaultCacheBehavior.DefaultTTL = aws.Int64(defaultTTL)
 }
 
-func (d *Distribution) Create(callerReference string, domains []string, origin, path string, defaultTTL int64, forwardedHeaders Headers, forwardCookies bool, tags map[string]string) (*cloudfront.Distribution, error) {
+func (d *Distribution) Create(callerReference string, domains []string, origin string, defaultTTL int64, forwardedHeaders Headers, forwardCookies bool, tags map[string]string) (*cloudfront.Distribution, error) {
 	distConfig := new(cloudfront.DistributionConfig)
 
 	distConfig.DefaultCacheBehavior = &cloudfront.DefaultCacheBehavior{
@@ -239,7 +237,6 @@ func (d *Distribution) Create(callerReference string, domains []string, origin, 
 		distConfig,
 		domains,
 		origin,
-		path,
 		defaultTTL,
 		forwardedHeaders,
 		forwardCookies,
@@ -259,7 +256,7 @@ func (d *Distribution) Create(callerReference string, domains []string, origin, 
 	return resp.Distribution, nil
 }
 
-func (d *Distribution) Update(distId string, domains []string, origin, path string, defaultTTL int64, forwardedHeaders Headers, forwardCookies bool) (*cloudfront.Distribution, error) {
+func (d *Distribution) Update(distId string, domains []string, origin string, defaultTTL int64, forwardedHeaders Headers, forwardCookies bool) (*cloudfront.Distribution, error) {
 	// Get the current distribution
 	dist, err := d.Service.GetDistributionConfig(&cloudfront.GetDistributionConfigInput{
 		Id: aws.String(distId),
@@ -279,7 +276,6 @@ func (d *Distribution) Update(distId string, domains []string, origin, path stri
 		dist.DistributionConfig,
 		domains,
 		origin,
-		path,
 		defaultTTL,
 		forwardedHeaders,
 		forwardCookies,

--- a/utils/cloudfront.go
+++ b/utils/cloudfront.go
@@ -122,7 +122,8 @@ func (d *Distribution) setDistributionConfigOrigins(config *cloudfront.Distribut
 		Quantity: aws.Int64(2),
 		Items: []*cloudfront.Origin{
 			{
-				Id: aws.String(callerReference),
+				Id:         aws.String(callerReference),
+				OriginPath: aws.String(""),
 				CustomHeaders: &cloudfront.CustomHeaders{
 					Quantity: aws.Int64(0),
 				},

--- a/utils/cloudfront.go
+++ b/utils/cloudfront.go
@@ -256,7 +256,14 @@ func (d *Distribution) Create(callerReference string, domains []string, origin s
 	return resp.Distribution, nil
 }
 
-func (d *Distribution) Update(distId string, domains []string, origin string, defaultTTL int64, forwardedHeaders Headers, forwardCookies bool) (*cloudfront.Distribution, error) {
+func (d *Distribution) Update(
+	distId string,
+	domains []string,
+	origin string,
+	defaultTTL int64,
+	forwardedHeaders Headers,
+	forwardCookies bool,
+) (*cloudfront.Distribution, error) {
 	// Get the current distribution
 	dist, err := d.Service.GetDistributionConfig(&cloudfront.GetDistributionConfigInput{
 		Id: aws.String(distId),


### PR DESCRIPTION
What
----

A salient commit message content which describes the what and the why:

```
UpdateOptions should be pointers

If you have a struct like

type UpdateOptions struct {
	Domain     string   `json:"domain"`
	DefaultTTL int64    `json:"default_ttl"`
	Cookies    bool     `json:"cookies"`
	Headers    []string `json:"headers"`
}

And you unmarshal '{}' into it

then the struct will have default values of "" for a string, 0 for an
int64, [] for an array, etc

If you have a struct like

type UpdateOptions struct {
	Domain     *string   `json:"domain,omitempty"`
	DefaultTTL *int64    `json:"default_ttl,omitempty"`
	Cookies    *bool     `json:"cookies,omitempty"`
	Headers    *[]string `json:"headers,omitempty"`
}

And you unmarshal {}' into it

then the struct will have nil values for *string, *int64, *[] etc

This is important. Currently if you

$ cf update-service my-cdn-route -c '{"domain": "my.domain.com", "headers": ["Accept", "Authorization"]}'

Then the headers will be set correctly

Then later, you do

$ cf update-service my-cdn-route -c '{"domain": "my.domain.com,my.otherdomain.com"}'

The resultant CDN distribution will have the headers reset

Now this not the case because we can distinguish between an empty list
and a not-provided list. This can be formalised as the difference
between Bool and Maybe<Bool>, where nil or not functions as the Maybe
monad.
```

How to review
----

Code review, commit by commit - I can squash afterwards in necessary.

Test in [tlwr development environment](https://admin.tlwr.dev.cloudpipeline.digital/):
- [x] Create
- [x] Update `-c {"cookies": false}` - check that cookies are set not to forward
- [x] Update `-c {"cookies": true}` - check that cookies are set to forward
- [x] Update `-c {"cookies": false}` - check that cookies are set to forward
- [x] Update `-c {"headers": ["Authorization"]}` - check that the Host and Authorization headers are forwarding, and that the cookies are set to forward
- [x] Update `-c {"default_ttl": 5}` - check that default TTL is updated, but the Headers and Cookies have not been changed
- [x] Update to add a new domain
- [x] Delete


Deploy [this commit](https://github.com/alphagov/paas-cf/commit/9e86e8b40a42db0732a978ebfd9b000e4558211a) to your development environment, should you wish to test it there

Who can review
----

Not @tlwr