### PR TITLE
Show if DNS changes need making

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -254,6 +254,15 @@ To validate ownership of the domain, set the following DNS records
 			"Service instance provisioned [%s => %s]; CDN domain %s",
 			route.DomainExternal, route.Origin, route.DomainInternal,
 		)
+
+		if !route.IsCertificateManagedByACM {
+			description += `
+
+Your CDN route service requires an update to migrate it a new certificate authority
+
+Please see our documentation at https://docs.cloud.service.gov.uk/deploying_services/use_a_custom_domain/#you-may-need-to-make-a-dns-change`
+		}
+
 		lsession.Info("ok", lager.Data{
 			"domain":      route.DomainExternal,
 			"state":       route.State,

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -192,14 +192,7 @@ func (b *CdnServiceBroker) LastOperation(
 			})
 			return brokerapi.LastOperation{}, err
 		}
-		if len(instructions) != len(route.GetDomains()) {
-			err = fmt.Errorf("Expected to find %d tokens; found %d", len(route.GetDomains()), len(instructions))
-			lsession.Error("too-few-dns-instructions", err, lager.Data{
-				"domain": route.DomainExternal,
-				"state":  route.State,
-			})
-			return brokerapi.LastOperation{}, err
-		}
+
 		var description string
 
 		cloudFrontCNAMES := []string{}

--- a/broker/broker_last_operation_test.go
+++ b/broker/broker_last_operation_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Last operation", func() {
 
 		operation, err := b.LastOperation(s.ctx, "123", brokerapi.PollDetails{OperationData: ""})
 		Expect(operation.State).To(Equal(brokerapi.Succeeded))
-		Expect(operation.Description).To(Equal("Service instance provisioned [cdn.cloud.gov => cdn.apps.cloud.gov]; CDN domain abc.cloudfront.net"))
+		Expect(operation.Description).To(ContainSubstring("Service instance provisioned [cdn.cloud.gov => cdn.apps.cloud.gov]; CDN domain abc.cloudfront.net"))
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
What
---
Shows if a provisioned CDN route service needs a DNS change. Also removes an unnecessary failure state.

How to review
--
1. Create a CDN route if your dev env
2. Go to the CDN broker database and set the flag `managed_by_acm` to `0` for the service
3. Push [the dev release](https://github.com/alphagov/paas-cdn-broker-boshrelease/pull/36) in to your env
4. Run `cf service SERVICE_NAME` and see if the output says an update is needed

Who can review
---
Anyone