### PR TITLE
cf domain ownership checking: also check for parent domains

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -61,7 +61,7 @@ var (
 	MaxHeaderCount = 10
 
 	// not very strict - only to prevent extreme mischief
-	isValidDomain = regexp.MustCompile("^[A-Za-z0-9.-]+$").MatchString
+	isValidDomain = regexp.MustCompile("^[A-Za-z0-9][A-Za-z0-9.-]*[A-Za-z0-9]$").MatchString
 
 	errDomainOrParentNotFound = errors.New("domain-or-parent-not-found")
 )

--- a/broker/broker_provision_test.go
+++ b/broker/broker_provision_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Provision", func() {
 
 		details := domain.ProvisionDetails{
 			OrganizationGUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
-			RawParameters: []byte(`{"domain": "domain1.gov"}`),
+			RawParameters: []byte(`{"domain": "domain1.cloud.gov"}`),
 		}
 		_, err := s.Broker.Provision(s.ctx, "123", details, true)
 
@@ -93,7 +93,24 @@ var _ = Describe("Provision", func() {
 
 		details := domain.ProvisionDetails{
 			OrganizationGUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
-			RawParameters: []byte(`{"domain": "domain1.gov"}`),
+			RawParameters: []byte(`{"domain": "domain1.cloud.gov"}`),
+		}
+		_, err := s.Broker.Provision(s.ctx, "123", details, true)
+
+		Expect(err).NotTo(HaveOccurred())
+		s.cfclient.AssertExpectations(GinkgoT())
+	})
+
+	It("Should succeed when a parent domain is owned in cloudfoundry", func() {
+		s.Manager.GetReturns(&models.Route{}, errors.New("not found"))
+		route := &models.Route{State: models.Provisioning}
+		s.Manager.CreateReturns(route, nil)
+
+		s.setupCFClientListV3DomainsDomain7()
+
+		details := domain.ProvisionDetails{
+			OrganizationGUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
+			RawParameters: []byte(`{"domain": "domain7.rain.gov"}`),
 		}
 		_, err := s.Broker.Provision(s.ctx, "123", details, true)
 
@@ -111,7 +128,7 @@ var _ = Describe("Provision", func() {
 		details := domain.ProvisionDetails{
 			OrganizationGUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
 			RawParameters: []byte(`{
-				"domain": "domain1.gov",
+				"domain": "domain1.cloud.gov",
 				"default_ttl": 52
 			}`),
 		}
@@ -134,7 +151,7 @@ var _ = Describe("Provision", func() {
 
 		details := domain.ProvisionDetails{
 			OrganizationGUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
-			RawParameters:    []byte(`{"domain": "domain1.gov"}`),
+			RawParameters:    []byte(`{"domain": "domain1.cloud.gov"}`),
 			SpaceGUID:        "space-1",
 			ServiceID:        "service-1",
 			PlanID:           "plan-1",
@@ -161,13 +178,13 @@ var _ = Describe("Provision", func() {
 		
 		details := domain.ProvisionDetails{
 			OrganizationGUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
-			RawParameters:    []byte(`{"domain": "domain3.gov"}`),
+			RawParameters:    []byte(`{"domain": "domain3.cloud.gov"}`),
 		}
 		_, err := s.Broker.Provision(s.ctx, "123", details, true)
 
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(
-			"Domain domain3.gov does not exist in CloudFoundry; create it with: cf create-domain domain3.gov my-org",
+			"Domain domain3.cloud.gov does not exist in CloudFoundry; create it with: cf create-domain domain3.cloud.gov my-org",
 		))
 		s.cfclient.AssertExpectations(GinkgoT())
 	})
@@ -179,13 +196,13 @@ var _ = Describe("Provision", func() {
 
 		details := domain.ProvisionDetails{
 			OrganizationGUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
-			RawParameters:    []byte(`{"domain": "domain1.gov,domain3.gov"}`),
+			RawParameters:    []byte(`{"domain": "domain1.cloud.gov,domain3.cloud.gov"}`),
 		}
 		_, err := s.Broker.Provision(s.ctx, "123", details, true)
 
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(
-			"Domain domain3.gov does not exist in CloudFoundry; create it with: cf create-domain domain3.gov my-org",
+			"Domain domain3.cloud.gov does not exist in CloudFoundry; create it with: cf create-domain domain3.cloud.gov my-org",
 		))
 		s.cfclient.AssertExpectations(GinkgoT())
 	})
@@ -198,15 +215,15 @@ var _ = Describe("Provision", func() {
 
 		details := domain.ProvisionDetails{
 			OrganizationGUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
-			RawParameters:    []byte(`{"domain": "domain1.gov,domain4.gov,domain3.gov"}`),
+			RawParameters:    []byte(`{"domain": "domain1.cloud.gov,domain4.four.cloud.gov,domain3.cloud.gov"}`),
 		}
 		_, err := s.Broker.Provision(s.ctx, "123", details, true)
 
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(
 `Multiple domains do not exist in CloudFoundry; create them with:
-cf create-domain domain4.gov my-org
-cf create-domain domain3.gov my-org`,
+cf create-domain domain4.four.cloud.gov my-org
+cf create-domain domain3.cloud.gov my-org`,
 		))
 		s.cfclient.AssertExpectations(GinkgoT())
 	})
@@ -217,13 +234,13 @@ cf create-domain domain3.gov my-org`,
 
 		details := domain.ProvisionDetails{
 			OrganizationGUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
-			RawParameters:    []byte(`{"domain": "domain4.gov"}`),
+			RawParameters:    []byte(`{"domain": "domain4.four.cloud.gov"}`),
 		}
 		_, err := s.Broker.Provision(s.ctx, "123", details, true)
 
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(
-			"Domain domain4.gov does not exist in CloudFoundry; create it with: cf create-domain domain4.gov <organization>",
+			"Domain domain4.four.cloud.gov does not exist in CloudFoundry; create it with: cf create-domain domain4.four.cloud.gov <organization>",
 		))
 		s.cfclient.AssertExpectations(GinkgoT())
 	})
@@ -231,13 +248,13 @@ cf create-domain domain3.gov my-org`,
 	It("Should error when given an domain using invalid characters", func() {
 		details := domain.ProvisionDetails{
 			OrganizationGUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
-			RawParameters:    []byte(`{"domain": "domain&.gov"}`),
+			RawParameters:    []byte(`{"domain": "domain&.cloud.gov"}`),
 		}
 		_, err := s.Broker.Provision(s.ctx, "123", details, true)
 
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(
-			"Domain domain&.gov doesn't look like a valid domain",
+			"Domain domain&.cloud.gov doesn't look like a valid domain",
 		))
 		s.cfclient.AssertExpectations(GinkgoT())
 	})
@@ -247,13 +264,13 @@ cf create-domain domain3.gov my-org`,
 
 		details := domain.ProvisionDetails{
 			OrganizationGUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
-			RawParameters:    []byte(`{"domain": "domain5.gov"}`),
+			RawParameters:    []byte(`{"domain": "domain5.cloud.gov"}`),
 		}
 		_, err := s.Broker.Provision(s.ctx, "123", details, true)
 
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(
-			"Domain domain5.gov is owned by a different organization in CloudFoundry",
+			"Domain domain5.cloud.gov is owned by a different organization in CloudFoundry",
 		))
 		s.cfclient.AssertExpectations(GinkgoT())
 	})
@@ -264,13 +281,13 @@ cf create-domain domain3.gov my-org`,
 
 		details := domain.ProvisionDetails{
 			OrganizationGUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
-			RawParameters:    []byte(`{"domain": "domain6.gov,domain5.gov"}`),
+			RawParameters:    []byte(`{"domain": "domain6.cloud.gov,domain5.cloud.gov"}`),
 		}
 		_, err := s.Broker.Provision(s.ctx, "123", details, true)
 
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(
-			"Multiple domains are owned by a different organization in CloudFoundry: domain6.gov, domain5.gov",
+			"Multiple domains are owned by a different organization in CloudFoundry: domain6.cloud.gov, domain5.cloud.gov",
 		))
 		s.cfclient.AssertExpectations(GinkgoT())
 	})
@@ -282,13 +299,13 @@ cf create-domain domain3.gov my-org`,
 
 		details := domain.ProvisionDetails{
 			OrganizationGUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
-			RawParameters:    []byte(`{"domain": "domain1.gov,domain6.gov,domain2.gov"}`),
+			RawParameters:    []byte(`{"domain": "domain1.cloud.gov,domain6.cloud.gov,domain2.cloud.gov"}`),
 		}
 		_, err := s.Broker.Provision(s.ctx, "123", details, true)
 
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(
-			"Domain domain6.gov is owned by a different organization in CloudFoundry",
+			"Domain domain6.cloud.gov is owned by a different organization in CloudFoundry",
 		))
 		s.cfclient.AssertExpectations(GinkgoT())
 	})
@@ -301,13 +318,29 @@ cf create-domain domain3.gov my-org`,
 
 		details := domain.ProvisionDetails{
 			OrganizationGUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
-			RawParameters:    []byte(`{"domain": "domain1.gov,domain6.gov,domain4.gov"}`),
+			RawParameters:    []byte(`{"domain": "domain1.cloud.gov,domain6.cloud.gov,domain4.four.cloud.gov"}`),
 		}
 		_, err := s.Broker.Provision(s.ctx, "123", details, true)
 
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(
-			"Domain domain4.gov does not exist in CloudFoundry; create it with: cf create-domain domain4.gov my-org",
+			"Domain domain4.four.cloud.gov does not exist in CloudFoundry; create it with: cf create-domain domain4.four.cloud.gov my-org",
+		))
+		s.cfclient.AssertExpectations(GinkgoT())
+	})
+
+	It("Should error when a parent Cloud Foundry domain doesn't belong to the organization", func() {
+		s.setupCFClientListV3DomainsDomain8()
+
+		details := domain.ProvisionDetails{
+			OrganizationGUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
+			RawParameters:    []byte(`{"domain": "domain8.wet.snow.gov"}`),
+		}
+		_, err := s.Broker.Provision(s.ctx, "123", details, true)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(
+			"Domain domain8.wet.snow.gov is owned by a different organization in CloudFoundry",
 		))
 		s.cfclient.AssertExpectations(GinkgoT())
 	})
@@ -323,7 +356,7 @@ cf create-domain domain3.gov my-org`,
 
 			details := domain.ProvisionDetails{
 				OrganizationGUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
-				RawParameters: []byte(`{"domain": "domain1.gov", "headers": ["Host"]}`),
+				RawParameters: []byte(`{"domain": "domain1.cloud.gov", "headers": ["Host"]}`),
 			}
 			_, err := s.Broker.Provision(s.ctx, "123", details, true)
 
@@ -337,7 +370,7 @@ cf create-domain domain3.gov my-org`,
 
 			details := domain.ProvisionDetails{
 				OrganizationGUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
-				RawParameters: []byte(`{"domain": "domain1.gov", "headers": ["User-Agent"]}`),
+				RawParameters: []byte(`{"domain": "domain1.cloud.gov", "headers": ["User-Agent"]}`),
 			}
 			_, err := s.Broker.Provision(s.ctx, "123", details, true)
 
@@ -351,7 +384,7 @@ cf create-domain domain3.gov my-org`,
 
 			details := domain.ProvisionDetails{
 				OrganizationGUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
-				RawParameters: []byte(`{"domain": "domain1.gov", "headers": ["*"]}`),
+				RawParameters: []byte(`{"domain": "domain1.cloud.gov", "headers": ["*"]}`),
 			}
 			_, err := s.Broker.Provision(s.ctx, "123", details, true)
 
@@ -365,7 +398,7 @@ cf create-domain domain3.gov my-org`,
 
 			details := domain.ProvisionDetails{
 				OrganizationGUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
-				RawParameters: []byte(`{"domain": "domain1.gov", "headers": ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine"]}`),
+				RawParameters: []byte(`{"domain": "domain1.cloud.gov", "headers": ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine"]}`),
 			}
 			_, err := s.Broker.Provision(s.ctx, "123", details, true)
 
@@ -378,7 +411,7 @@ cf create-domain domain3.gov my-org`,
 
 			details := domain.ProvisionDetails{
 				OrganizationGUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
-				RawParameters: []byte(`{"domain": "domain1.gov", "headers": ["User-Agent", "Host", "User-Agent"]}`),
+				RawParameters: []byte(`{"domain": "domain1.cloud.gov", "headers": ["User-Agent", "Host", "User-Agent"]}`),
 			}
 			_, err := s.Broker.Provision(s.ctx, "123", details, true)
 
@@ -392,7 +425,7 @@ cf create-domain domain3.gov my-org`,
 
 			details := domain.ProvisionDetails{
 				OrganizationGUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
-				RawParameters: []byte(`{"domain": "domain1.gov", "headers": ["*", "User-Agent"]}`),
+				RawParameters: []byte(`{"domain": "domain1.cloud.gov", "headers": ["*", "User-Agent"]}`),
 			}
 			_, err := s.Broker.Provision(s.ctx, "123", details, true)
 
@@ -406,7 +439,7 @@ cf create-domain domain3.gov my-org`,
 
 			details := domain.ProvisionDetails{
 				OrganizationGUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
-				RawParameters: []byte(`{"domain": "domain1.gov", "headers": ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"]}`),
+				RawParameters: []byte(`{"domain": "domain1.cloud.gov", "headers": ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"]}`),
 			}
 			_, err := s.Broker.Provision(s.ctx, "123", details, true)
 

--- a/broker/broker_provision_test.go
+++ b/broker/broker_provision_test.go
@@ -245,7 +245,7 @@ cf create-domain domain3.cloud.gov my-org`,
 		s.cfclient.AssertExpectations(GinkgoT())
 	})
 
-	It("Should error when given an domain using invalid characters", func() {
+	It("Should error when given a domain using invalid characters", func() {
 		details := domain.ProvisionDetails{
 			OrganizationGUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
 			RawParameters:    []byte(`{"domain": "domain&.cloud.gov"}`),
@@ -255,6 +255,20 @@ cf create-domain domain3.cloud.gov my-org`,
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(
 			"Domain domain&.cloud.gov doesn't look like a valid domain",
+		))
+		s.cfclient.AssertExpectations(GinkgoT())
+	})
+
+	It("Should error when given a domain with a trailing dot", func() {
+		details := domain.ProvisionDetails{
+			OrganizationGUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
+			RawParameters:    []byte(`{"domain": "domain.cloud.gov."}`),
+		}
+		_, err := s.Broker.Provision(s.ctx, "123", details, true)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(
+			"Domain domain.cloud.gov. doesn't look like a valid domain",
 		))
 		s.cfclient.AssertExpectations(GinkgoT())
 	})

--- a/broker/broker_update_test.go
+++ b/broker/broker_update_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Update", func() {
 			headers *utils.Headers,
 			forwardCookies *bool) (bool, error) {
 
-			if *updateDomain == "domain1.gov" &&
+			if *updateDomain == "domain1.cloud.gov" &&
 				ttl == defaultTTLNotPassed &&
 				headers == forwardedHeadersNotPassed &&
 				forwardCookies == forwardCookiesNotPassed {
@@ -66,7 +66,39 @@ var _ = Describe("Update", func() {
 		s.setupCFClientListV3DomainsDomain1()
 
 		details := domain.UpdateDetails{
-			RawParameters: json.RawMessage(`{"domain": "domain1.gov"}`),
+			RawParameters: json.RawMessage(`{"domain": "domain1.cloud.gov"}`),
+			PreviousValues: domain.PreviousValues{
+				OrgID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
+			},
+		}
+		_, err := s.Broker.Update(s.ctx, "123", details, true)
+		Expect(err).NotTo(HaveOccurred())
+		s.cfclient.AssertExpectations(GinkgoT())
+	})
+
+	It("Should succeed when given only a domain whose parent domain is owned in CloudFoundry", func() {
+		s.Manager.UpdateStub = func(
+			_ string,
+			updateDomain *string,
+			ttl *int64,
+			headers *utils.Headers,
+			forwardCookies *bool) (bool, error) {
+
+			if *updateDomain == "domain7.rain.gov" &&
+				ttl == defaultTTLNotPassed &&
+				headers == forwardedHeadersNotPassed &&
+				forwardCookies == forwardCookiesNotPassed {
+
+				return false, nil
+			} else {
+				return false, errors.New("unexpected arguments")
+			}
+		}
+
+		s.setupCFClientListV3DomainsDomain7()
+
+		details := domain.UpdateDetails{
+			RawParameters: json.RawMessage(`{"domain": "domain7.rain.gov"}`),
 			PreviousValues: domain.PreviousValues{
 				OrgID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
 			},
@@ -86,13 +118,13 @@ var _ = Describe("Update", func() {
 			PreviousValues: domain.PreviousValues{
 				OrgID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
 			},
-			RawParameters: json.RawMessage(`{"domain": "domain3.gov"}`),
+			RawParameters: json.RawMessage(`{"domain": "domain3.cloud.gov"}`),
 		}
 		_, err := s.Broker.Update(s.ctx, "123", details, true)
 
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(
-			"Domain domain3.gov does not exist in CloudFoundry; create it with: cf create-domain domain3.gov my-org",
+			"Domain domain3.cloud.gov does not exist in CloudFoundry; create it with: cf create-domain domain3.cloud.gov my-org",
 		))
 		s.cfclient.AssertExpectations(GinkgoT())
 	})
@@ -108,13 +140,13 @@ var _ = Describe("Update", func() {
 			PreviousValues: domain.PreviousValues{
 				OrgID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
 			},
-			RawParameters: json.RawMessage(`{"domain": "domain3.gov,domain2.gov"}`),
+			RawParameters: json.RawMessage(`{"domain": "domain3.cloud.gov,domain2.cloud.gov"}`),
 		}
 		_, err := s.Broker.Update(s.ctx, "123", details, true)
 
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(
-			"Domain domain3.gov does not exist in CloudFoundry; create it with: cf create-domain domain3.gov my-org",
+			"Domain domain3.cloud.gov does not exist in CloudFoundry; create it with: cf create-domain domain3.cloud.gov my-org",
 		))
 		s.cfclient.AssertExpectations(GinkgoT())
 	})
@@ -131,15 +163,15 @@ var _ = Describe("Update", func() {
 			PreviousValues: domain.PreviousValues{
 				OrgID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
 			},
-			RawParameters: json.RawMessage(`{"domain": "domain3.gov,domain2.gov,domain4.gov"}`),
+			RawParameters: json.RawMessage(`{"domain": "domain3.cloud.gov,domain2.cloud.gov,domain4.four.cloud.gov"}`),
 		}
 		_, err := s.Broker.Update(s.ctx, "123", details, true)
 
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(
 `Multiple domains do not exist in CloudFoundry; create them with:
-cf create-domain domain3.gov my-org
-cf create-domain domain4.gov my-org`,
+cf create-domain domain3.cloud.gov my-org
+cf create-domain domain4.four.cloud.gov my-org`,
 		))
 		s.cfclient.AssertExpectations(GinkgoT())
 	})
@@ -156,22 +188,22 @@ cf create-domain domain4.gov my-org`,
 			PreviousValues: domain.PreviousValues{
 				OrgID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
 			},
-			RawParameters: json.RawMessage(`{"domain": "domain3.gov,domain2.gov,domain4.gov"}`),
+			RawParameters: json.RawMessage(`{"domain": "domain3.cloud.gov,domain2.cloud.gov,domain4.four.cloud.gov"}`),
 		}
 		_, err := s.Broker.Update(s.ctx, "123", details, true)
 
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(
 `Multiple domains do not exist in CloudFoundry; create them with:
-cf create-domain domain3.gov <organization>
-cf create-domain domain4.gov <organization>`,
+cf create-domain domain3.cloud.gov <organization>
+cf create-domain domain4.four.cloud.gov <organization>`,
 		))
 		s.cfclient.AssertExpectations(GinkgoT())
 	})
 
 	It("Should error when given an domain using invalid characters", func() {
 		details := domain.UpdateDetails{
-			RawParameters: json.RawMessage(`{"domain": "domain!.gov"}`),
+			RawParameters: json.RawMessage(`{"domain": "domain!.cloud.gov"}`),
 			PreviousValues: domain.PreviousValues{
 				OrgID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
 			},
@@ -180,7 +212,7 @@ cf create-domain domain4.gov <organization>`,
 
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(
-			"Domain domain!.gov doesn't look like a valid domain",
+			"Domain domain!.cloud.gov doesn't look like a valid domain",
 		))
 		s.cfclient.AssertExpectations(GinkgoT())
 	})
@@ -194,13 +226,13 @@ cf create-domain domain4.gov <organization>`,
 			PreviousValues: domain.PreviousValues{
 				OrgID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
 			},
-			RawParameters: json.RawMessage(`{"domain": "domain6.gov"}`),
+			RawParameters: json.RawMessage(`{"domain": "domain6.cloud.gov"}`),
 		}
 		_, err := s.Broker.Update(s.ctx, "123", details, true)
 
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(
-			"Domain domain6.gov is owned by a different organization in CloudFoundry",
+			"Domain domain6.cloud.gov is owned by a different organization in CloudFoundry",
 		))
 		s.cfclient.AssertExpectations(GinkgoT())
 	})
@@ -215,13 +247,13 @@ cf create-domain domain4.gov <organization>`,
 			PreviousValues: domain.PreviousValues{
 				OrgID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
 			},
-			RawParameters: json.RawMessage(`{"domain": "domain6.gov,domain5.gov"}`),
+			RawParameters: json.RawMessage(`{"domain": "domain6.cloud.gov,domain5.cloud.gov"}`),
 		}
 		_, err := s.Broker.Update(s.ctx, "123", details, true)
 
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(
-			"Multiple domains are owned by a different organization in CloudFoundry: domain6.gov, domain5.gov",
+			"Multiple domains are owned by a different organization in CloudFoundry: domain6.cloud.gov, domain5.cloud.gov",
 		))
 		s.cfclient.AssertExpectations(GinkgoT())
 	})
@@ -237,13 +269,13 @@ cf create-domain domain4.gov <organization>`,
 			PreviousValues: domain.PreviousValues{
 				OrgID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
 			},
-			RawParameters: json.RawMessage(`{"domain": "domain5.gov,domain1.gov,domain2.gov"}`),
+			RawParameters: json.RawMessage(`{"domain": "domain5.cloud.gov,domain1.cloud.gov,domain2.cloud.gov"}`),
 		}
 		_, err := s.Broker.Update(s.ctx, "123", details, true)
 
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(
-			"Domain domain5.gov is owned by a different organization in CloudFoundry",
+			"Domain domain5.cloud.gov is owned by a different organization in CloudFoundry",
 		))
 		s.cfclient.AssertExpectations(GinkgoT())
 	})
@@ -259,13 +291,33 @@ cf create-domain domain4.gov <organization>`,
 			PreviousValues: domain.PreviousValues{
 				OrgID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
 			},
-			RawParameters: json.RawMessage(`{"domain": "domain4.gov,domain6.gov"}`),
+			RawParameters: json.RawMessage(`{"domain": "domain4.four.cloud.gov,domain6.cloud.gov"}`),
 		}
 		_, err := s.Broker.Update(s.ctx, "123", details, true)
 
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(
-			"Domain domain4.gov does not exist in CloudFoundry; create it with: cf create-domain domain4.gov my-org",
+			"Domain domain4.four.cloud.gov does not exist in CloudFoundry; create it with: cf create-domain domain4.four.cloud.gov my-org",
+		))
+		s.cfclient.AssertExpectations(GinkgoT())
+	})
+
+	It("Should error when a parent Cloud Foundry domain doesn't belong to the organization", func() {
+		s.Manager.UpdateReturns(true, nil)
+
+		s.setupCFClientListV3DomainsDomain8()
+
+		details := domain.UpdateDetails{
+			PreviousValues: domain.PreviousValues{
+				OrgID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
+			},
+			RawParameters: json.RawMessage(`{"domain": "domain8.wet.snow.gov"}`),
+		}
+		_, err := s.Broker.Update(s.ctx, "123", details, true)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(
+			"Domain domain8.wet.snow.gov is owned by a different organization in CloudFoundry",
 		))
 		s.cfclient.AssertExpectations(GinkgoT())
 	})
@@ -281,7 +333,7 @@ cf create-domain domain4.gov <organization>`,
 					OrgID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
 				},
 				RawParameters: json.RawMessage(`{
-			"domain": "domain1.gov",
+			"domain": "domain1.cloud.gov",
 			"headers": ["Host"]
 		}`),
 			}
@@ -299,7 +351,7 @@ cf create-domain domain4.gov <organization>`,
 					OrgID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
 				},
 				RawParameters: json.RawMessage(`{
-			"domain": "domain1.gov",
+			"domain": "domain1.cloud.gov",
 			"headers": ["User-Agent"]
 		}`),
 			}
@@ -317,7 +369,7 @@ cf create-domain domain4.gov <organization>`,
 					OrgID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
 				},
 				RawParameters: json.RawMessage(`{
-			"domain": "domain1.gov",
+			"domain": "domain1.cloud.gov",
 			"headers": ["*"]
 		}`),
 			}
@@ -335,7 +387,7 @@ cf create-domain domain4.gov <organization>`,
 					OrgID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
 				},
 				RawParameters: json.RawMessage(`{
-			"domain": "domain1.gov",
+			"domain": "domain1.cloud.gov",
 			"headers": ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine"]
 		}`),
 			}
@@ -353,7 +405,7 @@ cf create-domain domain4.gov <organization>`,
 					OrgID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
 				},
 				RawParameters: json.RawMessage(`{
-			"domain": "domain1.gov",
+			"domain": "domain1.cloud.gov",
 			"headers": ["*", "User-Agent"]
 		}`),
 			}
@@ -370,7 +422,7 @@ cf create-domain domain4.gov <organization>`,
 					OrgID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
 				},
 				RawParameters: json.RawMessage(`{
-			"domain": "domain1.gov",
+			"domain": "domain1.cloud.gov",
 			"headers": ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"]
 		}`),
 			}

--- a/broker/broker_update_test.go
+++ b/broker/broker_update_test.go
@@ -201,7 +201,7 @@ cf create-domain domain4.four.cloud.gov <organization>`,
 		s.cfclient.AssertExpectations(GinkgoT())
 	})
 
-	It("Should error when given an domain using invalid characters", func() {
+	It("Should error when given a domain using invalid characters", func() {
 		details := domain.UpdateDetails{
 			RawParameters: json.RawMessage(`{"domain": "domain!.cloud.gov"}`),
 			PreviousValues: domain.PreviousValues{
@@ -213,6 +213,22 @@ cf create-domain domain4.four.cloud.gov <organization>`,
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(
 			"Domain domain!.cloud.gov doesn't look like a valid domain",
+		))
+		s.cfclient.AssertExpectations(GinkgoT())
+	})
+
+	It("Should error when given a domain with a trailing dot", func() {
+		details := domain.UpdateDetails{
+			RawParameters: json.RawMessage(`{"domain": "domain.cloud.gov.,foo.cloud.gov"}`),
+			PreviousValues: domain.PreviousValues{
+				OrgID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
+			},
+		}
+		_, err := s.Broker.Update(s.ctx, "123", details, true)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(
+			"Domain domain.cloud.gov. doesn't look like a valid domain",
 		))
 		s.cfclient.AssertExpectations(GinkgoT())
 	})

--- a/broker/broker_util_test.go
+++ b/broker/broker_util_test.go
@@ -47,15 +47,15 @@ func (s *ProvisionUpdateSuite) allowCreateWithExpectedHeaders(expectedHeaders ut
 	}
 }
 
-// setup cf response for domain1.gov, directly owned by test org
+// setup cf response for domain1.cloud.gov, directly owned by test org
 func (s *ProvisionUpdateSuite) setupCFClientListV3DomainsDomain1() {
-	q , _ := url.ParseQuery("names=domain1.gov")
+	q , _ := url.ParseQuery("names=domain1.cloud.gov")
 	s.cfclient.On(
 		"ListV3Domains",
 		q,
 	).Return([]cfclient.V3Domain{
 		{
-			Name: "domain.gov",
+			Name: "domain.cloud.gov",
 			Relationships: cfclient.DomainRelationships{
 				Organization: cfclient.V3ToOneRelationship{
 					Data: cfclient.V3Relationship{
@@ -67,15 +67,15 @@ func (s *ProvisionUpdateSuite) setupCFClientListV3DomainsDomain1() {
 	}, nil)
 }
 
-// setup cf response for domain2.gov, shared with test org
+// setup cf response for domain2.cloud.gov, shared with test org
 func (s *ProvisionUpdateSuite) setupCFClientListV3DomainsDomain2() {
-	q , _ := url.ParseQuery("names=domain2.gov")
+	q , _ := url.ParseQuery("names=domain2.cloud.gov")
 	s.cfclient.On(
 		"ListV3Domains",
 		q,
 	).Return([]cfclient.V3Domain{
 		{
-			Name: "domain2.gov",
+			Name: "domain2.cloud.gov",
 			Relationships: cfclient.DomainRelationships{
 				Organization: cfclient.V3ToOneRelationship{
 					Data: cfclient.V3Relationship{
@@ -93,33 +93,51 @@ func (s *ProvisionUpdateSuite) setupCFClientListV3DomainsDomain2() {
 	}, nil)
 }
 
-// setup cf response for domain3.gov, not known
+// setup cf response for domain3.cloud.gov, not known
 func (s *ProvisionUpdateSuite) setupCFClientListV3DomainsDomain3() {
-	q , _ := url.ParseQuery("names=domain3.gov")
+	q , _ := url.ParseQuery("names=domain3.cloud.gov")
+	s.cfclient.On(
+		"ListV3Domains",
+		q,
+	).Return([]cfclient.V3Domain{}, nil)
+	// followup query looking for parent
+	q , _ = url.ParseQuery("names=cloud.gov")
 	s.cfclient.On(
 		"ListV3Domains",
 		q,
 	).Return([]cfclient.V3Domain{}, nil)
 }
 
-// setup cf response for domain4.gov, not known
+// setup cf response for domain4.four.cloud.gov, not known
 func (s *ProvisionUpdateSuite) setupCFClientListV3DomainsDomain4() {
-	q , _ := url.ParseQuery("names=domain4.gov")
+	q , _ := url.ParseQuery("names=domain4.four.cloud.gov")
+	s.cfclient.On(
+		"ListV3Domains",
+		q,
+	).Return([]cfclient.V3Domain{}, nil)
+	// followup query looking for parent
+	q , _ = url.ParseQuery("names=four.cloud.gov")
+	s.cfclient.On(
+		"ListV3Domains",
+		q,
+	).Return([]cfclient.V3Domain{}, nil)
+	// followup query looking for parent
+	q , _ = url.ParseQuery("names=cloud.gov")
 	s.cfclient.On(
 		"ListV3Domains",
 		q,
 	).Return([]cfclient.V3Domain{}, nil)
 }
 
-// setup cf response for domain5.gov, shared but not with test org
+// setup cf response for domain5.cloud.gov, shared but not with test org
 func (s *ProvisionUpdateSuite) setupCFClientListV3DomainsDomain5() {
-	q , _ := url.ParseQuery("names=domain5.gov")
+	q , _ := url.ParseQuery("names=domain5.cloud.gov")
 	s.cfclient.On(
 		"ListV3Domains",
 		q,
 	).Return([]cfclient.V3Domain{
 		{
-			Name: "domain5.gov",
+			Name: "domain5.cloud.gov",
 			Relationships: cfclient.DomainRelationships{
 				Organization: cfclient.V3ToOneRelationship{
 					Data: cfclient.V3Relationship{
@@ -136,19 +154,74 @@ func (s *ProvisionUpdateSuite) setupCFClientListV3DomainsDomain5() {
 	}, nil)
 }
 
-// setup cf response for domain6.gov, not owned by test org
+// setup cf response for domain6.cloud.gov, not owned by test org
 func (s *ProvisionUpdateSuite) setupCFClientListV3DomainsDomain6() {
-	q , _ := url.ParseQuery("names=domain6.gov")
+	q , _ := url.ParseQuery("names=domain6.cloud.gov")
 	s.cfclient.On(
 		"ListV3Domains",
 		q,
 	).Return([]cfclient.V3Domain{
 		{
-			Name: "domain6.gov",
+			Name: "domain6.cloud.gov",
 			Relationships: cfclient.DomainRelationships{
 				Organization: cfclient.V3ToOneRelationship{
 					Data: cfclient.V3Relationship{
 						GUID: "22222222-3333-4444-5555-666666666666",
+					},
+				},
+			},
+		},
+	}, nil)
+}
+
+// setup cf response for domain7.rain.gov, rain.gov directly owned by test org
+func (s *ProvisionUpdateSuite) setupCFClientListV3DomainsDomain7() {
+	q , _ := url.ParseQuery("names=domain7.rain.gov")
+	s.cfclient.On(
+		"ListV3Domains",
+		q,
+	).Return([]cfclient.V3Domain{}, nil)
+	q , _ = url.ParseQuery("names=rain.gov")
+	s.cfclient.On(
+		"ListV3Domains",
+		q,
+	).Return([]cfclient.V3Domain{
+		{
+			Name: "rain.gov",
+			Relationships: cfclient.DomainRelationships{
+				Organization: cfclient.V3ToOneRelationship{
+					Data: cfclient.V3Relationship{
+						GUID: "dfb39134-ab7d-489e-ae59-4ed5c6f42fb5",
+					},
+				},
+			},
+		},
+	}, nil)
+}
+
+// setup cf response for domain8.wet.snow.gov, wet.snow.gov not shared but not with test org
+func (s *ProvisionUpdateSuite) setupCFClientListV3DomainsDomain8() {
+	q , _ := url.ParseQuery("names=domain8.wet.snow.gov")
+	s.cfclient.On(
+		"ListV3Domains",
+		q,
+	).Return([]cfclient.V3Domain{}, nil)
+	q , _ = url.ParseQuery("names=wet.snow.gov")
+	s.cfclient.On(
+		"ListV3Domains",
+		q,
+	).Return([]cfclient.V3Domain{
+		{
+			Name: "wet.snow.gov",
+			Relationships: cfclient.DomainRelationships{
+				Organization: cfclient.V3ToOneRelationship{
+					Data: cfclient.V3Relationship{
+						GUID: "22222222-3333-4444-5555-666666666666",
+					},
+				},
+				SharedOrganizations: cfclient.V3ToManyRelationships{
+					Data: []cfclient.V3Relationship{
+						{ GUID: "11111111-2222-3333-4444-555555555555" },
 					},
 				},
 			},

--- a/cf/client.go
+++ b/cf/client.go
@@ -10,3 +10,5 @@ type Client interface {
 	ListV3Domains(query url.Values) ([]cfclient.V3Domain, error)
 	GetOrgByGuid(guid string) (cfclient.Org, error)
 }
+
+type V3Domain = cfclient.V3Domain


### PR DESCRIPTION
The original upstream code only ever checked for exact domain ownership in cloudfoundry, but ensuring cf domains exist for each subdomain in a cdn route causes problems when trying to register cf routes as it complains of a collision with the domain of the same name. So the most practical thing to do is have people register the parent domains in cloudfoundry.

Support looking up a parent domain in cloudfoundry if the exact domain isn't found.

Some basic checking shows that cloudfoundry won't allow a subdomain to be owned by a different organization to the one that owns the parent domain, so there shouldn't be any danger of hijacking with such a configuration.