### PR TITLE
Add makefile option to bosh scp built binary to an existing bosh environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ _testmain.go
 *.prof
 
 credentials.yml
+
+# Temporary Build Files
+amd64/*

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,13 @@ test:
 .PHONY: fakes
 fakes:
 	go generate ./...
+
+.PHONY: build_amd64
+build_amd64:
+	mkdir -p amd64
+	GOOS=linux GOARCH=amd64 go build -o amd64/cdn-broker github.com/alphagov/paas-cdn-broker/cmd/cdn-broker
+	GOOS=linux GOARCH=amd64 go build -o amd64/cdn-cron github.com/alphagov/paas-cdn-broker/cmd/cdn-cron
+
+.PHONY: bosh_scp
+bosh_scp: build_amd64
+	./scripts/bosh-scp.sh

--- a/scripts/bosh-scp.sh
+++ b/scripts/bosh-scp.sh
@@ -1,0 +1,36 @@
+#!/bin/bash 
+
+set -euo pipefail
+
+function run_command() {
+    local command=$1
+    local message=$2
+
+    echo -n "${message}... "
+
+    if ! output=$(bash -c "${command}" 2>&1); then
+        echo -e "failed.\n\n"
+        echo "Command Failed: ${command}"
+        echo ""
+        echo "Output: ${output}"
+        exit 1
+    fi
+    echo "done."
+}
+
+command -v jq >/dev/null 2>&1 || { echo >&2 "jq is required but it's not installed.  Aborting."; exit 1; }
+command -v bosh >/dev/null 2>&1 || { echo >&2 "bosh is required but it's not installed.  Aborting."; exit 1; }
+command -v cut >/dev/null 2>&1 || { echo >&2 "cut is required but it's not installed.  Aborting."; exit 1; }
+
+
+bosh vms --json | jq -r '.Tables[0].Rows[] | select(.instance|startswith("cdn_broker/")) | .instance' | while read -r instance; do
+    run_command "bosh ssh ${instance} sudo monit stop cdn-broker" "stopping cdn-broker on ${instance}"
+    run_command "bosh ssh ${instance} sudo monit stop cdn-cron" "stopping cdn-cron on ${instance}"
+    run_command "bosh scp ./amd64/cdn-broker ${instance}:/tmp/cdn-broker" "copying cdn-broker binary to tmp on ${instance}"
+    run_command "bosh scp ./amd64/cdn-cron ${instance}:/tmp/cdn-cron" "copying cdn-cron binary to tmp on ${instance}"
+    run_command "bosh ssh ${instance} sudo mv /tmp/cdn-broker /var/vcap/packages/cdn-broker/bin/cdn-broker" "moving cdn-broker binary from tmp to packages on ${instance}"
+    run_command "bosh ssh ${instance} sudo mv /tmp/cdn-cron /var/vcap/packages/cdn-broker/bin/cdn-cron" "moving cdn-cron binary from tmp to packages on ${instance}"
+    run_command "bosh ssh ${instance} sudo monit start cdn-broker" "starting cdn-broker on ${instance}"
+    run_command "bosh ssh ${instance} sudo monit start cdn-cron" "starting cdn-cron on ${instance}"
+done
+


### PR DESCRIPTION
What
----

Add a make bosh_scp target for building and deploying into an existing environment.

Why
----

This allows a more rapid way to deploy and test your changes in an existing environment

How to review
-------------

Test it