### PR TITLE
GetInstance: include cloudfront distribution id

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -109,8 +109,10 @@ func (b *CdnServiceBroker) GetInstance(ctx context.Context, instanceID string, d
 
 	forwardCookies := aws.StringValue(distribution.DistributionConfig.DefaultCacheBehavior.ForwardedValues.Cookies.Forward) == "all"
 	cacheTTL := aws.Int64Value(distribution.DistributionConfig.DefaultCacheBehavior.DefaultTTL)
+	distributionId := aws.StringValue(distribution.Id)
 
 	instanceParams := map[string]interface{}{
+		"cloudfront_distribution_id": distributionId,
 		"cloudfront_domain": route.DomainInternal,
 		"dns_records":       challenges,
 		"forwarded_headers": headers,

--- a/broker/broker_get_instance_test.go
+++ b/broker/broker_get_instance_test.go
@@ -188,6 +188,16 @@ var _ = Describe("GetInstance", func() {
 			Expect(params["forwarded_headers"]).To(ConsistOf("Host", "Authorization"))
 		})
 
+		It("should return the cloudfront distribution id in the instance parameters", func() {
+			instance, err := s.Broker.GetInstance(s.ctx, instanceId, domain.FetchInstanceDetails{})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(instance.Parameters).ToNot(BeNil())
+			params, err := instanceParamsToMap(instance.Parameters)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(params).To(HaveKeyWithValue("cloudfront_distribution_id", "distribution-1"))
+		})
+
 		It("should return the cookie forwarding configuration in the instance parameters", func() {
 			instance, err := s.Broker.GetInstance(s.ctx, instanceId, domain.FetchInstanceDetails{})
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/183923174

Simple change, simple unit test.

## How to test

Could use https://github.com/alphagov/paas-cdn-broker-boshrelease/pull/53 to deploy this to a dev env and test. At time of writing this is deployed in `dev04`, and an example (working) cdn service instance has been created in the `govuk-paas`/`tools` space, which you should be able to perform a `cf service ... --params` on to see the output.