### PR TITLE
Update to go 1.22

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,10 +3,9 @@ on: [push, pull_request]
 env:
   GO_VERSION: "1.22"
 jobs:
-
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,7 @@
 name: Go
 on: [push, pull_request]
 env:
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.22"
 jobs:
 
   build:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-cdn-broker
 
-go 1.21
+go 1.22
 
 require (
 	cloud.google.com/go v0.43.0 // indirect

--- a/manifest-base.yml
+++ b/manifest-base.yml
@@ -4,4 +4,4 @@ memory: 128M
 services:
 - rds-cdn-broker
 env:
-  GOVERSION: go1.21
+  GOVERSION: go1.22


### PR DESCRIPTION
## What

Use go v1.22

## Why

To be able to update buildpacks

## How to review

Ensure that this broker deploys okay to a dev environment and passes tests

## Who can review

Current PaaS team members

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨